### PR TITLE
[ECH-5265] feat(jfrog): library mirror support (PyPI/npm/maven) + per-format resource names

### DIFF
--- a/echo-pulumi-jfrog-mirror/README.md
+++ b/echo-pulumi-jfrog-mirror/README.md
@@ -1,6 +1,9 @@
 # Echo JFrog Remote Repository - Pulumi Component
 
-Purpose: Minimal Pulumi component to set up JFrog Artifactory remote repository for Echo Registry.
+Pulumi component that configures JFrog Artifactory as a proxy for Echo. One
+component provisions a Docker remote for **images** and/or PyPI / npm / Maven
+remotes for **libraries**, based on the inputs. Each repository is created only
+when its flag is set.
 
 ## Install
 ```bash
@@ -12,48 +15,43 @@ pulumi package add github.com/buildecho/onboarding-providers/echo-pulumi-jfrog-m
 import { JfrogIntegration } from "@buildecho/echo-pulumi-jfrog-mirror";
 
 const integration = new JfrogIntegration("echo-integration", {
-  echoAccessKeyName: "your-echo-username",
-  echoAccessKeyValue: "your-echo-password",
-  remoteRepositoryKey: "echo",              // default
-  echoRegistryUrl: "https://reg.echohq.com" // default
+  // Images
+  echoImages: true,
+  echoImageKeyName: config.requireSecret("echoImageKeyName"),
+  echoImageKeyValue: config.requireSecret("echoImageKeyValue"),
+
+  // Libraries (one shared library key)
+  echoLibraryPypi: true,
+  echoLibraryNpm: true,
+  echoLibraryKeyName: config.requireSecret("echoLibraryKeyName"),
+  echoLibraryKeyValue: config.requireSecret("echoLibraryKeyValue"),
 });
 
-export const repositoryUrl = integration.repositoryUrl;
 export const usageInstructions = integration.usageInstructions;
 ```
 
 ## Inputs
-- `echoAccessKeyName` (string, required): Echo Registry access key name (username)
-- `echoAccessKeyValue` (string, required): Echo Registry access key value (password)
-- `remoteRepositoryName` (string, default: `echo`): The name for the remote repository in Artifactory
-- `echoRegistryUrl` (string, default: `https://reg.echohq.com`): The URL of the Echo registry
-- `description` (string, default: `Echo Registry remote repository for container images`): Repository description
-- `notes` (string, default: `Managed by Pulumi - Echo Registry integration`): Internal notes about the repository
-- `includesPattern` (string, default: `**/*`): Comma-separated list of patterns to include when evaluating artifact requests
-- `excludesPattern` (string, default: `""`): Comma-separated list of patterns to exclude when evaluating artifact requests
-- `repoLayoutRef` (string, default: `simple-default`): Repository layout reference
-- `blockMismatchingMimeTypes` (boolean, default: `true`): Block artifacts with mismatching MIME types
-- `enableTokenAuthentication` (boolean, default: `true`): Enable token authentication for Docker repositories
-- `storeArtifactsLocally` (boolean, default: `true`): Store artifacts locally when proxying
-- `socketTimeoutMillis` (number, default: `15000`): Network socket timeout in milliseconds
-- `retrievalCachePeriodSeconds` (number, default: `7200`): Cache period for retrieval operations in seconds
-- `missedCachePeriodSeconds` (number, default: `1800`): Cache period for missed artifacts in seconds
-- `hardFail` (boolean, default: `false`): Fail the request if the remote repository is not available
-- `offline` (boolean, default: `false`): Set the repository to offline mode
-- `bypassHeadRequests` (boolean, default: `false`): Bypass HEAD requests and directly perform GET requests
-- `priorityResolution` (boolean, default: `false`): Enable priority resolution
-- `xrayIndex` (boolean, default: `false`): Enable Xray indexing
-- `propertySets` (string[], default: `["artifactory"]`): List of property sets to apply to the repository
-- `tags` (Record<string, string>, optional): Additional tags to apply to created resources
+
+### Images
+- `echoImages` (boolean, default `false`) — provision the Docker remote
+- `echoImageKeyName` / `echoImageKeyValue` — image access key
+- `echoImageRepositoryName` (string, default → `remoteRepositoryName`)
+- `echoRegistryUrl` (string, default `https://reg.echohq.com`)
+- `echoAccessKeyName` / `echoAccessKeyValue` — **deprecated**, backwards-compatible image fields
+
+### Libraries (one shared library key)
+- `echoLibraryPypi` / `echoLibraryNpm` / `echoLibraryMaven` (boolean, default `false`)
+- `echoLibraryKeyName` / `echoLibraryKeyValue` — library access key
+- `echoPypiUrl` / `echoNpmUrl` / `echoMavenUrl` (defaults `https://{pypi,npm,maven}.echohq.com`)
+- `echoPypiRepositoryName` / `echoNpmRepositoryName` / `echoMavenRepositoryName`
+  (default → `<remoteRepositoryName>-{pypi,npm,maven}`)
+
+### Shared
+- `remoteRepositoryName` (string, default `echo`) — base name; per-format repos derive from it
+- `description`, `notes`, `includesPattern`, `excludesPattern`, `repoLayoutRef`,
+  `blockMismatchingMimeTypes`, `enableTokenAuthentication`, `storeArtifactsLocally`,
+  `socketTimeoutMillis`, `retrievalCachePeriodSeconds`, `missedCachePeriodSeconds`,
+  `hardFail`, `offline`, `bypassHeadRequests`, `priorityResolution`, `xrayIndex`, `propertySets`
 
 ## Outputs
-- `usageInstructions`: Docker pull command template
-
-## Test
-```bash
-# Login to your JFrog Artifactory instance
-docker login your-artifactory-url
-
-# Pull an Echo image through JFrog
-docker pull your-artifactory-url/echo/<image>:<tag>
-``` 
+- `usageInstructions` — per-format pull/install instructions (replace `<your-jfrog-domain>`)

--- a/echo-pulumi-jfrog-mirror/index.ts
+++ b/echo-pulumi-jfrog-mirror/index.ts
@@ -2,164 +2,141 @@ import * as pulumi from "@pulumi/pulumi";
 import * as artifactory from "@pulumi/artifactory";
 
 /**
- * Configuration options for the JFrog Integration with Echo Registry
+ * Configuration options for the JFrog Integration with Echo.
+ *
+ * One component orchestrates the image (Docker) remote and the library (PyPI /
+ * npm / Maven) remotes; each is provisioned only when its flag is set. Images
+ * use the image access key, libraries share the library access key.
  */
 export interface JfrogIntegrationInput {
     /**
-     * The key (name) for the remote repository in Artifactory
+     * Base name for the remote repositories. Per-format repositories derive from
+     * it (<name>, <name>-pypi, <name>-npm, <name>-maven) unless overridden.
      * @default "echo"
      */
     remoteRepositoryName?: string;
 
+    // --- Images (container registry) ---
+
+    /** Provision the Docker remote that proxies Echo's image registry. */
+    echoImages?: boolean;
+
+    /** Echo image access key name (username) for the Docker remote. */
+    echoImageKeyName?: pulumi.Input<string>;
+
+    /** Echo image access key value (password) for the Docker remote. */
+    echoImageKeyValue?: pulumi.Input<string>;
+
+    /** Optional override for the Docker remote key. Defaults to remoteRepositoryName. */
+    echoImageRepositoryName?: string;
+
     /**
-     * The URL of the Echo registry
+     * URL of the Echo image registry.
      * @default "https://reg.echohq.com"
      */
     echoRegistryUrl?: string;
 
     /**
-     * The name of the Echo access key (username)
+     * @deprecated Use echoImageKeyName. Kept for backwards compatibility with the
+     * original image-only component; provisions the Docker remote when set.
      */
-    echoAccessKeyName: pulumi.Input<string>;
+    echoAccessKeyName?: pulumi.Input<string>;
 
-    /**
-     * The value of the Echo access key (password)
-     */
-    echoAccessKeyValue: pulumi.Input<string>;
+    /** @deprecated Use echoImageKeyValue. */
+    echoAccessKeyValue?: pulumi.Input<string>;
 
-    /**
-     * Description for the remote repository
-     * @default "Echo Registry remote repository for container images"
-     */
+    // --- Libraries (package registries), one shared library key ---
+
+    /** Provision the PyPI remote that proxies Echo's PyPI index. */
+    echoLibraryPypi?: boolean;
+
+    /** Provision the npm remote that proxies Echo's npm index. */
+    echoLibraryNpm?: boolean;
+
+    /** Provision the Maven remote that proxies Echo's Maven index. */
+    echoLibraryMaven?: boolean;
+
+    /** Echo library access key name (username) for the library remotes. */
+    echoLibraryKeyName?: pulumi.Input<string>;
+
+    /** Echo library access key value (password) for the library remotes. */
+    echoLibraryKeyValue?: pulumi.Input<string>;
+
+    /** @default "https://pypi.echohq.com" */
+    echoPypiUrl?: string;
+
+    /** @default "https://npm.echohq.com" */
+    echoNpmUrl?: string;
+
+    /** @default "https://maven.echohq.com" */
+    echoMavenUrl?: string;
+
+    /** Optional override for the PyPI remote key. Defaults to <name>-pypi. */
+    echoPypiRepositoryName?: string;
+
+    /** Optional override for the npm remote key. Defaults to <name>-npm. */
+    echoNpmRepositoryName?: string;
+
+    /** Optional override for the Maven remote key. Defaults to <name>-maven. */
+    echoMavenRepositoryName?: string;
+
+    // --- Shared remote-repository configuration ---
+
+    /** @default "Echo remote repository" */
     description?: string;
-
-    /**
-     * Internal notes about the repository
-     * @default "Managed by Pulumi - Echo Registry integration"
-     */
+    /** @default "Managed by Pulumi - Echo integration" */
     notes?: string;
-
-    /**
-     * Comma-separated list of patterns to include when evaluating artifact requests
-     * @default "**\/*"
-     */
+    /** @default "**\/*" */
     includesPattern?: string;
-
-    /**
-     * Comma-separated list of patterns to exclude when evaluating artifact requests
-     * @default ""
-     */
+    /** @default "" */
     excludesPattern?: string;
-
-    /**
-     * Repository layout reference
-     * @default "simple-default"
-     */
+    /** Docker repo layout reference. @default "simple-default" */
     repoLayoutRef?: string;
-
-    /**
-     * Block artifacts with mismatching MIME types
-     * @default true
-     */
+    /** @default true */
     blockMismatchingMimeTypes?: boolean;
-
-    /**
-     * Enable token authentication for Docker repositories
-     * @default true
-     */
+    /** @default true */
     enableTokenAuthentication?: boolean;
-
-    /**
-     * Store artifacts locally when proxying
-     * @default true
-     */
+    /** @default true */
     storeArtifactsLocally?: boolean;
-
-    /**
-     * Network socket timeout in milliseconds
-     * @default 15000
-     */
+    /** @default 15000 */
     socketTimeoutMillis?: number;
-
-    /**
-     * Cache period for retrieval operations in seconds
-     * @default 7200
-     */
+    /** @default 7200 */
     retrievalCachePeriodSeconds?: number;
-
-    /**
-     * Cache period for missed artifacts in seconds
-     * @default 1800
-     */
+    /** @default 1800 */
     missedCachePeriodSeconds?: number;
-
-    /**
-     * Fail the request if the remote repository is not available
-     * @default false
-     */
+    /** @default false */
     hardFail?: boolean;
-
-    /**
-     * Set the repository to offline mode
-     * @default false
-     */
+    /** @default false */
     offline?: boolean;
-
-    /**
-     * Bypass HEAD requests and directly perform GET requests
-     * @default false
-     */
+    /** @default false */
     bypassHeadRequests?: boolean;
-
-    /**
-     * Enable priority resolution
-     * @default false
-     */
+    /** @default false */
     priorityResolution?: boolean;
-
-    /**
-     * Enable Xray indexing
-     * @default false
-     */
+    /** @default false */
     xrayIndex?: boolean;
-
-    /**
-     * List of property sets to apply to the repository
-     * @default []
-     */
+    /** @default ["artifactory"] */
     propertySets?: string[];
-
-    /**
-     * Additional tags to apply to created resources
-     */
-    tags?: Record<string, string>;
 }
 
 /**
- * Outputs from the JFrog Integration component
- */
-export interface JfrogIntegrationOutputs {
-    /**
-     * Human-readable usage instructions
-     */
-    usageInstructions: pulumi.Output<string>;
-}
-
-/**
- * JFrog Integration Component
- * 
- * This component sets up a JFrog Artifactory remote repository to integrate with Echo's registry,
- * allowing you to proxy Echo images through your Artifactory instance.
- * 
+ * JFrog Integration Component.
+ *
+ * Provisions Artifactory remote repositories that proxy Echo — a Docker remote
+ * for images and PyPI/npm/Maven remotes for libraries — based on the inputs.
+ *
  * @example
  * ```typescript
  * import { JfrogIntegration } from "@buildecho/echo-pulumi-jfrog-mirror";
- * 
+ *
  * const integration = new JfrogIntegration("echo-integration", {
- *     echoAccessKeyName: config.requireSecret("echoAccessKeyName"),
- *     echoAccessKeyValue: config.requireSecret("echoAccessKeyValue")
+ *     echoImages: true,
+ *     echoImageKeyName: config.requireSecret("echoImageKeyName"),
+ *     echoImageKeyValue: config.requireSecret("echoImageKeyValue"),
+ *     echoLibraryPypi: true,
+ *     echoLibraryKeyName: config.requireSecret("echoLibraryKeyName"),
+ *     echoLibraryKeyValue: config.requireSecret("echoLibraryKeyValue"),
  * });
- * 
+ *
  * export const instructions = integration.usageInstructions;
  * ```
  */
@@ -169,60 +146,99 @@ export class JfrogIntegration extends pulumi.ComponentResource {
     constructor(name: string, args: JfrogIntegrationInput, opts?: pulumi.ComponentResourceOptions) {
         super("echo-pulumi-jfrog-mirror:index:JfrogIntegration", name, args, opts);
 
-        // Set defaults
         const repositoryName = args.remoteRepositoryName || "echo";
-        const echoRegistryUrl = args.echoRegistryUrl || "https://reg.echohq.com";
-        const description = args.description || "Echo Registry remote repository for container images";
-        const notes = args.notes || "Managed by Pulumi - Echo Registry integration";
+        const description = args.description || "Echo remote repository";
+        const notes = args.notes || "Managed by Pulumi - Echo integration";
         const includesPattern = args.includesPattern || "**/*";
         const excludesPattern = args.excludesPattern || "";
-        const repoLayoutRef = args.repoLayoutRef || "simple-default";
-        const blockMismatchingMimeTypes = args.blockMismatchingMimeTypes ?? true;
-        const enableTokenAuthentication = args.enableTokenAuthentication ?? true;
         const storeArtifactsLocally = args.storeArtifactsLocally ?? true;
         const socketTimeoutMillis = args.socketTimeoutMillis || 15000;
         const retrievalCachePeriodSeconds = args.retrievalCachePeriodSeconds || 7200;
         const missedCachePeriodSeconds = args.missedCachePeriodSeconds || 1800;
         const hardFail = args.hardFail ?? false;
         const offline = args.offline ?? false;
-        const bypassHeadRequests = args.bypassHeadRequests ?? false;
-        const priorityResolution = args.priorityResolution ?? false;
-        const xrayIndex = args.xrayIndex ?? false;
-        const propertySets = args.propertySets || ["artifactory"];
 
-        // Create the remote Docker repository
-        const remoteRepository = new artifactory.RemoteDockerRepository(`${name}-remote`, {
-            key: repositoryName,
-            url: echoRegistryUrl,
-            username: args.echoAccessKeyName,
-            password: args.echoAccessKeyValue,
-            description: description,
-            notes: notes,
-            includesPattern: includesPattern,
-            excludesPattern: excludesPattern,
-            repoLayoutRef: repoLayoutRef,
-            blockMismatchingMimeTypes: blockMismatchingMimeTypes,
-            enableTokenAuthentication: enableTokenAuthentication,
-            storeArtifactsLocally: storeArtifactsLocally,
-            socketTimeoutMillis: socketTimeoutMillis,
-            retrievalCachePeriodSeconds: retrievalCachePeriodSeconds,
-            missedCachePeriodSeconds: missedCachePeriodSeconds,
-            hardFail: hardFail,
-            offline: offline,
-            bypassHeadRequests: bypassHeadRequests,
-            priorityResolution: priorityResolution,
-            xrayIndex: xrayIndex,
-            propertySets: propertySets,
-        }, { parent: this });
+        const instructions: string[] = [];
 
-        // Set outputs
+        // --- Image (Docker) remote ---
+        // Provision when explicitly enabled, or (legacy) when a deprecated access
+        // key was supplied. Image key prefers the new field, falls back to access.
+        const createDocker = args.echoImages === true || args.echoAccessKeyName !== undefined;
+        if (createDocker) {
+            const imageRepository = args.echoImageRepositoryName || repositoryName;
+            new artifactory.RemoteDockerRepository(`${name}-remote`, {
+                key: imageRepository,
+                url: args.echoRegistryUrl || "https://reg.echohq.com",
+                username: args.echoImageKeyName ?? args.echoAccessKeyName ?? "",
+                password: args.echoImageKeyValue ?? args.echoAccessKeyValue ?? "",
+                description,
+                notes,
+                includesPattern,
+                excludesPattern,
+                repoLayoutRef: args.repoLayoutRef || "simple-default",
+                blockMismatchingMimeTypes: args.blockMismatchingMimeTypes ?? true,
+                enableTokenAuthentication: args.enableTokenAuthentication ?? true,
+                storeArtifactsLocally,
+                socketTimeoutMillis,
+                retrievalCachePeriodSeconds,
+                missedCachePeriodSeconds,
+                hardFail,
+                offline,
+                bypassHeadRequests: args.bypassHeadRequests ?? false,
+                priorityResolution: args.priorityResolution ?? false,
+                xrayIndex: args.xrayIndex ?? false,
+                propertySets: args.propertySets || ["artifactory"],
+            }, { parent: this });
+            instructions.push(`Images:  docker pull <your-jfrog-domain>/${imageRepository}/static:latest`);
+        }
 
-        // one line docker pull command
-        this.usageInstructions = pulumi.output(`docker pull <JFrog instance URL>/${repositoryName}/static:latest`);
-        // Register outputs
+        const libraryCommon = {
+            username: args.echoLibraryKeyName ?? "",
+            password: args.echoLibraryKeyValue ?? "",
+            description,
+            notes,
+            storeArtifactsLocally,
+            socketTimeoutMillis,
+            retrievalCachePeriodSeconds,
+            missedCachePeriodSeconds,
+            hardFail,
+            offline,
+        };
+
+        // --- Library remotes ---
+        if (args.echoLibraryPypi) {
+            const key = args.echoPypiRepositoryName || `${repositoryName}-pypi`;
+            new artifactory.RemotePypiRepository(`${name}-pypi`, {
+                key,
+                url: args.echoPypiUrl || "https://pypi.echohq.com",
+                ...libraryCommon,
+            }, { parent: this });
+            instructions.push(`PyPI:    pip install --index-url https://<your-jfrog-domain>/artifactory/api/pypi/${key}/simple <package>`);
+        }
+
+        if (args.echoLibraryNpm) {
+            const key = args.echoNpmRepositoryName || `${repositoryName}-npm`;
+            new artifactory.RemoteNpmRepository(`${name}-npm`, {
+                key,
+                url: args.echoNpmUrl || "https://npm.echohq.com",
+                ...libraryCommon,
+            }, { parent: this });
+            instructions.push(`npm:     npm install --registry https://<your-jfrog-domain>/artifactory/api/npm/${key}/ <package>`);
+        }
+
+        if (args.echoLibraryMaven) {
+            const key = args.echoMavenRepositoryName || `${repositoryName}-maven`;
+            new artifactory.RemoteMavenRepository(`${name}-maven`, {
+                key,
+                url: args.echoMavenUrl || "https://maven.echohq.com",
+                ...libraryCommon,
+            }, { parent: this });
+            instructions.push(`Maven:   add https://<your-jfrog-domain>/artifactory/${key} as a repository in your settings.xml`);
+        }
+
+        this.usageInstructions = pulumi.output(instructions.join("\n"));
         this.registerOutputs({
-            usageInstructions: this.usageInstructions
+            usageInstructions: this.usageInstructions,
         });
     }
-
 }

--- a/echo-pulumi-jfrog-mirror/index.ts
+++ b/echo-pulumi-jfrog-mirror/index.ts
@@ -116,6 +116,11 @@ export interface JfrogIntegrationInput {
     xrayIndex?: boolean;
     /** @default ["artifactory"] */
     propertySets?: string[];
+    /**
+     * @deprecated Accepted for backwards compatibility with the image-only
+     * module; not applied to any resource.
+     */
+    tags?: Record<string, string>;
 }
 
 /**

--- a/echo-terraform-jfrog-mirror/README.md
+++ b/echo-terraform-jfrog-mirror/README.md
@@ -1,61 +1,86 @@
 # Echo JFrog Artifactory Mirror - Terraform Module
 
-Purpose: Terraform module to configure JFrog Artifactory as a proxy cache for Echo Registry, enabling local caching and faster container image pulls.
+Configures JFrog Artifactory as a proxy for Echo. One module provisions a Docker
+remote for **images** and/or PyPI / npm / Maven remotes for **libraries**, based
+on the inputs. Each repository is created only when its flag is set.
 
 ## Quickstart
 
 ```hcl
-module "echo_artifactory_mirror" {
+module "echo_jfrog_mirror" {
   source = "git@github.com:buildecho/onboarding-providers.git//echo-terraform-jfrog-mirror"
 
-  echo_access_key_name     = var.echo_access_key_name
-  echo_access_key_value    = var.echo_access_key_value
+  # Images
+  echo_images          = true
+  echo_image_key_name  = var.echo_image_key_name
+  echo_image_key_value = var.echo_image_key_value
+
+  # Libraries (one shared library key)
+  echo_library_pypi      = true
+  echo_library_npm       = true
+  echo_library_key_name  = var.echo_library_key_name
+  echo_library_key_value = var.echo_library_key_value
+}
+
+output "usage_instructions" {
+  value = module.echo_jfrog_mirror.usage_instructions
 }
 ```
 
 ```bash
-terraform init && terraform apply -auto-approve
+terraform init && terraform apply
 ```
 
 ## Inputs
-- `create` (bool, default: `true`)
-- `echo_access_key_name` (string, required)
-- `echo_access_key_value` (string, required)
-- `remote_repository_name` (string, default: `"echo"`)
+
+### Images (container registry)
+- `echo_images` (bool, default: `false`) — provision the Docker remote
+- `echo_image_key_name` / `echo_image_key_value` (string, sensitive) — image access key
+- `echo_image_repository_name` (string, default: `""` → `remote_repository_name`)
 - `echo_registry_url` (string, default: `"https://reg.echohq.com"`)
-- `description` (string, default: `"Echo Registry remote repository for container images"`)
-- `notes` (string, default: `"Managed by Terraform - Echo Registry integration"`)
-- `includes_pattern` (string, default: `"**/*"`)
-- `excludes_pattern` (string, default: `""`)
-- `repo_layout_ref` (string, default: `"simple-default"`)
-- `block_mismatching_mime_types` (bool, default: `true`)
-- `enable_token_authentication` (bool, default: `true`)
+- `echo_access_key_name` / `echo_access_key_value` — **deprecated**, kept for backwards
+  compatibility; when set they provision the Docker remote using the image fields.
+
+### Libraries (package registries — one shared library key)
+- `echo_library_pypi` / `echo_library_npm` / `echo_library_maven` (bool, default: `false`)
+- `echo_library_key_name` / `echo_library_key_value` (string, sensitive) — library access key
+- `echo_pypi_url` (default: `"https://pypi.echohq.com"`)
+- `echo_npm_url` (default: `"https://npm.echohq.com"`)
+- `echo_maven_url` (default: `"https://maven.echohq.com"`)
+- `echo_pypi_repository_name` / `echo_npm_repository_name` / `echo_maven_repository_name`
+  (string, default: `""` → `<remote_repository_name>-{pypi,npm,maven}`)
+
+### Shared
+- `create` (bool, default: `true`)
+- `remote_repository_name` (string, default: `"echo"`) — base name; per-format repos derive from it
+- `description`, `notes`, `includes_pattern`, `excludes_pattern`, `repo_layout_ref`
+- `block_mismatching_mime_types`, `enable_token_authentication` (Docker only)
+- `store_artifacts_locally`, `socket_timeout_millis`, `retrieval_cache_period_seconds`,
+  `missed_cache_period_seconds`, `hard_fail`, `offline`, `bypass_head_requests`,
+  `priority_resolution`, `xray_index`, `property_sets`
 
 ## Outputs
-- `usage_instructions`: Docker pull command template
+- `usage_instructions` — per-format pull/install instructions (replace `<your-jfrog-domain>`)
+- `image_repository_key` — Docker remote key (or `null`)
+- `library_repository_keys` — list of created library remote keys
 
-## Example Usage
+## Example — custom repository names
+
 ```hcl
-module "echo_artifactory_mirror" {
+module "echo_jfrog_mirror" {
   source = "./echo-terraform-jfrog-mirror"
-  
-  echo_access_key_name     = var.echo_access_key_name
-  echo_access_key_value    = var.echo_access_key_value
-  remote_repository_name   = "echo-mirror"
+
+  remote_repository_name = "echo"
+
+  echo_images          = true
+  echo_image_key_name  = var.echo_image_key_name
+  echo_image_key_value = var.echo_image_key_value
+
+  echo_library_pypi          = true
+  echo_pypi_repository_name  = "echo-python" # overrides the default "echo-pypi"
+  echo_library_key_name      = var.echo_library_key_name
+  echo_library_key_value     = var.echo_library_key_value
 }
-
-output "usage" {
-  value = module.echo_artifactory_mirror.usage_instructions
-}
-```
-
-## Test
-```bash
-# Configure Docker to use Artifactory
-docker login your-artifactory.com
-
-# Pull through Artifactory mirror
-docker pull your-artifactory.com/echo-remote/static:latest
 ```
 
 ## Provider Configuration
@@ -65,19 +90,3 @@ provider "artifactory" {
   access_token = var.artifactory_access_token
 }
 ```
-
-## Advanced Configuration
-```hcl
-module "echo_artifactory_mirror" {
-  source = "./echo-terraform-jfrog-mirror"
-
-  remote_repository_name         = "echo-docker-remote"
-  echo_access_key_name           = var.echo_access_key_name
-  echo_access_key_value          = var.echo_access_key_value
-  
-  # Custom settings
-  store_artifacts_locally        = true
-  retrieval_cache_period_seconds = 7200
-  xray_index                     = true
-}
-``` 

--- a/echo-terraform-jfrog-mirror/main.tf
+++ b/echo-terraform-jfrog-mirror/main.tf
@@ -1,13 +1,30 @@
-# Terraform version requirements moved to versions.tf
+# Terraform version requirements live in versions.tf
 
-# Docker Remote Repository for Echo registry
+locals {
+  # Image key: prefer the new echo_image_key_*, fall back to the deprecated
+  # echo_access_key_* so existing image-only deployments keep working.
+  image_key_name  = var.echo_image_key_name != "" ? var.echo_image_key_name : var.echo_access_key_name
+  image_key_value = var.echo_image_key_value != "" ? var.echo_image_key_value : var.echo_access_key_value
+
+  # Provision the Docker remote when explicitly enabled, or (legacy) when a
+  # deprecated access key was supplied.
+  create_docker = var.create && (var.echo_images || nonsensitive(var.echo_access_key_name) != "")
+
+  # Per-format repository keys (overridable, otherwise derived from the base).
+  image_repository = var.echo_image_repository_name != "" ? var.echo_image_repository_name : var.remote_repository_name
+  pypi_repository  = var.echo_pypi_repository_name != "" ? var.echo_pypi_repository_name : "${var.remote_repository_name}-pypi"
+  npm_repository   = var.echo_npm_repository_name != "" ? var.echo_npm_repository_name : "${var.remote_repository_name}-npm"
+  maven_repository = var.echo_maven_repository_name != "" ? var.echo_maven_repository_name : "${var.remote_repository_name}-maven"
+}
+
+# Docker remote repository for Echo's image registry
 resource "artifactory_remote_docker_repository" "echo_remote" {
-  count = var.create ? 1 : 0
+  count = local.create_docker ? 1 : 0
 
-  key         = var.remote_repository_name
+  key         = local.image_repository
   url         = var.echo_registry_url
-  username    = var.echo_access_key_name
-  password    = var.echo_access_key_value
+  username    = local.image_key_name
+  password    = local.image_key_value
   description = var.description
 
   # Repository configuration
@@ -37,4 +54,61 @@ resource "artifactory_remote_docker_repository" "echo_remote" {
 
   # Property sets
   property_sets = length(var.property_sets) > 0 ? var.property_sets : ["artifactory"]
+}
+
+# PyPI remote repository for Echo's PyPI index
+resource "artifactory_remote_pypi_repository" "echo_pypi" {
+  count = var.create && var.echo_library_pypi ? 1 : 0
+
+  key         = local.pypi_repository
+  url         = var.echo_pypi_url
+  username    = var.echo_library_key_name
+  password    = var.echo_library_key_value
+  description = var.description
+  notes       = var.notes
+
+  store_artifacts_locally        = var.store_artifacts_locally
+  socket_timeout_millis          = var.socket_timeout_millis
+  retrieval_cache_period_seconds = var.retrieval_cache_period_seconds
+  missed_cache_period_seconds    = var.missed_cache_period_seconds
+  hard_fail                      = var.hard_fail
+  offline                        = var.offline
+}
+
+# npm remote repository for Echo's npm index
+resource "artifactory_remote_npm_repository" "echo_npm" {
+  count = var.create && var.echo_library_npm ? 1 : 0
+
+  key         = local.npm_repository
+  url         = var.echo_npm_url
+  username    = var.echo_library_key_name
+  password    = var.echo_library_key_value
+  description = var.description
+  notes       = var.notes
+
+  store_artifacts_locally        = var.store_artifacts_locally
+  socket_timeout_millis          = var.socket_timeout_millis
+  retrieval_cache_period_seconds = var.retrieval_cache_period_seconds
+  missed_cache_period_seconds    = var.missed_cache_period_seconds
+  hard_fail                      = var.hard_fail
+  offline                        = var.offline
+}
+
+# Maven remote repository for Echo's Maven index
+resource "artifactory_remote_maven_repository" "echo_maven" {
+  count = var.create && var.echo_library_maven ? 1 : 0
+
+  key         = local.maven_repository
+  url         = var.echo_maven_url
+  username    = var.echo_library_key_name
+  password    = var.echo_library_key_value
+  description = var.description
+  notes       = var.notes
+
+  store_artifacts_locally        = var.store_artifacts_locally
+  socket_timeout_millis          = var.socket_timeout_millis
+  retrieval_cache_period_seconds = var.retrieval_cache_period_seconds
+  missed_cache_period_seconds    = var.missed_cache_period_seconds
+  hard_fail                      = var.hard_fail
+  offline                        = var.offline
 }

--- a/echo-terraform-jfrog-mirror/outputs.tf
+++ b/echo-terraform-jfrog-mirror/outputs.tf
@@ -1,5 +1,23 @@
-
 output "usage_instructions" {
-  description = "Instructions for using the Artifactory proxy cache"
-  value       = var.create ? "docker pull <JFrog instance URL>/${var.remote_repository_name}/static:latest" : null
+  description = "Instructions for using the Echo remote repositories provisioned in Artifactory. Replace <your-jfrog-domain> with your Artifactory host."
+  value = var.create ? join("\n", compact([
+    local.create_docker ? "Images:  docker pull <your-jfrog-domain>/${local.image_repository}/static:latest" : "",
+    var.echo_library_pypi ? "PyPI:    pip install --index-url https://<your-jfrog-domain>/artifactory/api/pypi/${local.pypi_repository}/simple <package>" : "",
+    var.echo_library_npm ? "npm:     npm install --registry https://<your-jfrog-domain>/artifactory/api/npm/${local.npm_repository}/ <package>" : "",
+    var.echo_library_maven ? "Maven:   add https://<your-jfrog-domain>/artifactory/${local.maven_repository} as a repository in your settings.xml" : "",
+  ])) : null
+}
+
+output "image_repository_key" {
+  description = "Key of the Docker remote repository, if created."
+  value       = local.create_docker ? local.image_repository : null
+}
+
+output "library_repository_keys" {
+  description = "Keys of the library remote repositories that were created."
+  value = compact([
+    var.echo_library_pypi ? local.pypi_repository : "",
+    var.echo_library_npm ? local.npm_repository : "",
+    var.echo_library_maven ? local.maven_repository : "",
+  ])
 }

--- a/echo-terraform-jfrog-mirror/variables.tf
+++ b/echo-terraform-jfrog-mirror/variables.tf
@@ -6,38 +6,149 @@ variable "create" {
 
 variable "remote_repository_name" {
   type        = string
-  description = "The name for the remote repository in Artifactory"
+  description = "Base name for the remote repositories in Artifactory. Per-format repositories derive from it (e.g. <name>, <name>-pypi, <name>-npm, <name>-maven) unless overridden."
   default     = "echo"
+}
+
+# ---------------------------------------------------------------------------
+# Images (container registry)
+# ---------------------------------------------------------------------------
+
+variable "echo_images" {
+  type        = bool
+  description = "Provision the Docker remote repository that proxies Echo's image registry."
+  default     = false
+}
+
+variable "echo_image_key_name" {
+  type        = string
+  description = "Echo image access key name (username) for the Docker remote."
+  default     = ""
+  sensitive   = true
+}
+
+variable "echo_image_key_value" {
+  type        = string
+  description = "Echo image access key value (password) for the Docker remote."
+  default     = ""
+  sensitive   = true
+}
+
+variable "echo_image_repository_name" {
+  type        = string
+  description = "Optional override for the Docker remote repository key. Defaults to remote_repository_name."
+  default     = ""
 }
 
 variable "echo_registry_url" {
   type        = string
-  description = "The URL of the Echo registry"
+  description = "URL of the Echo image registry."
   default     = "https://reg.echohq.com"
 }
 
+# Deprecated: kept for backwards compatibility with the original image-only
+# module. When set (and the new echo_image_key_* are empty) it provisions the
+# Docker remote. Prefer echo_images + echo_image_key_name/value.
 variable "echo_access_key_name" {
   type        = string
-  description = "The name of the Echo access key (username)"
+  description = "Deprecated. Use echo_image_key_name. Echo access key name (username)."
+  default     = ""
   sensitive   = true
 }
 
 variable "echo_access_key_value" {
   type        = string
-  description = "The value of the Echo access key (password)"
+  description = "Deprecated. Use echo_image_key_value. Echo access key value (password)."
+  default     = ""
   sensitive   = true
 }
 
+# ---------------------------------------------------------------------------
+# Libraries (package registries) — one shared library key across ecosystems
+# ---------------------------------------------------------------------------
+
+variable "echo_library_pypi" {
+  type        = bool
+  description = "Provision the PyPI remote repository that proxies Echo's PyPI index."
+  default     = false
+}
+
+variable "echo_library_npm" {
+  type        = bool
+  description = "Provision the npm remote repository that proxies Echo's npm index."
+  default     = false
+}
+
+variable "echo_library_maven" {
+  type        = bool
+  description = "Provision the Maven remote repository that proxies Echo's Maven index."
+  default     = false
+}
+
+variable "echo_library_key_name" {
+  type        = string
+  description = "Echo library access key name (username) for the library remotes."
+  default     = ""
+  sensitive   = true
+}
+
+variable "echo_library_key_value" {
+  type        = string
+  description = "Echo library access key value (password) for the library remotes."
+  default     = ""
+  sensitive   = true
+}
+
+variable "echo_pypi_url" {
+  type        = string
+  description = "URL of the Echo PyPI index."
+  default     = "https://pypi.echohq.com"
+}
+
+variable "echo_npm_url" {
+  type        = string
+  description = "URL of the Echo npm index."
+  default     = "https://npm.echohq.com"
+}
+
+variable "echo_maven_url" {
+  type        = string
+  description = "URL of the Echo Maven index."
+  default     = "https://maven.echohq.com"
+}
+
+variable "echo_pypi_repository_name" {
+  type        = string
+  description = "Optional override for the PyPI remote repository key. Defaults to <remote_repository_name>-pypi."
+  default     = ""
+}
+
+variable "echo_npm_repository_name" {
+  type        = string
+  description = "Optional override for the npm remote repository key. Defaults to <remote_repository_name>-npm."
+  default     = ""
+}
+
+variable "echo_maven_repository_name" {
+  type        = string
+  description = "Optional override for the Maven remote repository key. Defaults to <remote_repository_name>-maven."
+  default     = ""
+}
+
+# ---------------------------------------------------------------------------
+# Shared remote-repository configuration
+# ---------------------------------------------------------------------------
+
 variable "description" {
   type        = string
-  description = "Description for the remote repository"
-  default     = "Echo Registry remote repository for container images"
+  description = "Description for the remote repositories"
+  default     = "Echo remote repository"
 }
 
 variable "notes" {
   type        = string
-  description = "Internal notes about the repository"
-  default     = "Managed by Terraform - Echo Registry integration"
+  description = "Internal notes about the repositories"
+  default     = "Managed by Terraform - Echo integration"
 }
 
 variable "includes_pattern" {
@@ -54,7 +165,7 @@ variable "excludes_pattern" {
 
 variable "repo_layout_ref" {
   type        = string
-  description = "Repository layout reference"
+  description = "Repository layout reference for the Docker remote"
   default     = "simple-default"
 }
 
@@ -126,6 +237,6 @@ variable "xray_index" {
 
 variable "property_sets" {
   type        = list(string)
-  description = "List of property sets to apply to the repository"
+  description = "List of property sets to apply to the repositories"
   default     = []
 }


### PR DESCRIPTION
## What
Extends the **JFrog** mirror module (Terraform + Pulumi) to provision **library** remotes (PyPI / npm / Maven) alongside the existing Docker image remote, matching the Echo Integrations UI contract (the rendered module invocation in platform PR #1273 / ECH-5246).

### Inputs (both TF & Pulumi)
- **Images:** `echo_images` + `echo_image_key_name`/`_value`, `echo_registry_url`, `echo_image_repository_name`
- **Libraries:** `echo_library_{pypi,npm,maven}` + a shared `echo_library_key_name`/`_value`, `echo_{pypi,npm,maven}_url`, `echo_{pypi,npm,maven}_repository_name`
- Each remote is created only when its flag is set; endpoints default to `reg/pypi/npm/maven.echohq.com` and are overridable.
- **Resource-name overrides** per format, the same way images already supported `remote_repository_name` (base `echo`; libraries derive `echo-pypi`/`echo-npm`/`echo-maven` unless overridden).

## Backwards compatibility
- Deprecated `echo_access_key_name`/`_value` still provision the Docker remote (image-key fallback), so existing image-only callers keep working.
- The Docker resource address is unchanged (`artifactory_remote_docker_repository.echo_remote`) → no state churn for existing deployments.

## Verification
- Terraform: `terraform validate` → **Success** (fixed a sensitive-output taint via `nonsensitive()` on the legacy access-key presence check).
- Pulumi: `tsc --noEmit` clean (`RemotePypiRepository` / `RemoteNpmRepository` / `RemoteMavenRepository` + props valid).
- READMEs updated for both modules.

Contract reference: ECH-5246. Implements ECH-5265 (I.6.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes IaC that provisions Artifactory remotes and handles credentials; misconfiguration could break pulls/installs, though Docker resource identity is preserved for existing deployments.
> 
> **Overview**
> Extends the **Terraform** and **Pulumi** JFrog Echo mirror modules so one integration can optionally provision **Docker** (images) and **PyPI / npm / Maven** (libraries) Artifactory remotes, each created only when its flag is set.
> 
> **Inputs** are split into image vs library credentials (`echo_image_key_*` / `echo_library_key_*`), per-format enable flags, overridable upstream URLs and repository keys (defaults derive from `remote_repository_name`, e.g. `echo-pypi`). Deprecated `echo_access_key_*` still triggers the Docker remote with key fallback so existing image-only callers keep working; Terraform uses `nonsensitive()` on the legacy key presence check for validate.
> 
> **Outputs** now include multi-line `usage_instructions` (docker / pip / npm / maven) and Terraform adds `image_repository_key` and `library_repository_keys`. READMEs are updated for the new contract; the Docker Terraform resource address is unchanged to avoid state churn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5891f76c6be90c451aea996478504ebf15eef627. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->