### PR TITLE
[ECH-5266] feat(nexus): Terraform library mirror support (PyPI/npm/maven)

### DIFF
--- a/echo-terraform-nexus-mirror/README.md
+++ b/echo-terraform-nexus-mirror/README.md
@@ -1,70 +1,96 @@
 # Echo Nexus Mirror - Terraform Module
 
-Purpose: Minimal Nexus Docker proxy repository to integrate with the Echo registry.
+Configures Sonatype Nexus as a proxy for Echo. One module provisions a Docker
+proxy for **images** and/or PyPI / npm / Maven proxies for **libraries**, based
+on the inputs. Each repository is created only when its flag is set.
 
 ## Quickstart
 
 ```hcl
-module "nexus_echo_proxy" {
+module "echo_nexus_mirror" {
   source = "git@github.com:buildecho/onboarding-providers.git//echo-terraform-nexus-mirror"
 
-  echo_access_key_name  = "your-echo-access-key-name"
-  echo_access_key_value = "your-echo-access-key-value"
-}
-```
+  # Images
+  echo_images          = true
+  echo_image_key_name  = var.echo_image_key_name
+  echo_image_key_value = var.echo_image_key_value
+  docker_http_port     = 2525
 
-```bash
-terraform init && terraform apply -auto-approve
-```
-
-## Inputs
-- `create` (bool, default: `true`)
-- `echo_registry_url` (string, default: `https://reg.echohq.com`)
-- `echo_access_key_name` (string, required, sensitive)
-- `echo_access_key_value` (string, required, sensitive)
-- `repository_name` (string, default: `echo`)
-- `repository_online` (bool, default: `true`)
-- `docker_force_basic_auth` (bool, default: `true`)
-- `docker_http_port` (number, optional)
-- `docker_https_port` (number, optional)
-- `docker_v1_enabled` (bool, default: `false`)
-- `docker_index_type` (string, default: `REGISTRY`)
-- `docker_index_url` (string, optional)
-- `blob_store_name` (string, default: `default`)
-- `strict_content_type_validation` (bool, default: `true`)
-- `proxy_content_max_age` (number, default: `1440`)
-- `proxy_metadata_max_age` (number, default: `1440`)
-- `http_client_blocked` (bool, default: `false`)
-- `http_client_auto_block` (bool, default: `true`)
-- `connection_retries` (number, default: `3`)
-- `connection_timeout` (number, default: `60`)
-- `negative_cache_enabled` (bool, default: `true`)
-- `negative_cache_ttl` (number, default: `1440`)
-- `create_content_selector` (bool, default: `false`)
-- `create_repository_privilege` (bool, default: `false`)
-- `tags` (map(string), optional)
-
-## Outputs
-- `usage_instructions`: Example Docker pull command
-
-## Example usage
-```hcl
-module "nexus_echo_proxy" {
-  source = "./echo-terraform-nexus-mirror"
-  
-  echo_access_key_name  = var.echo_access_key_name
-  echo_access_key_value = var.echo_access_key_value
+  # Libraries (one shared library key)
+  echo_library_pypi      = true
+  echo_library_npm       = true
+  echo_library_key_name  = var.echo_library_key_name
+  echo_library_key_value = var.echo_library_key_value
 }
 
 output "usage_instructions" {
-  value = module.nexus_echo_proxy.usage_instructions
+  value = module.echo_nexus_mirror.usage_instructions
 }
 ```
 
-## Test
 ```bash
-# Get usage instructions
-terraform output --raw usage_instructions
+terraform init && terraform apply
+```
 
-# Example: docker pull <nexus-host>:<port>/image:tag
-``` 
+## Inputs
+
+### Images (container registry)
+- `echo_images` (bool, default: `false`) — provision the Docker proxy
+- `echo_image_key_name` / `echo_image_key_value` (string, sensitive) — image access key
+- `echo_image_repository_name` (string, default: `""` → `repository_name`)
+- `echo_registry_url` (string, default: `"https://reg.echohq.com"`)
+- `docker_http_port` / `docker_https_port` (number, optional)
+- `echo_access_key_name` / `echo_access_key_value` — **deprecated**, kept for backwards
+  compatibility; when set they provision the Docker proxy using the image fields.
+
+### Libraries (package registries — one shared library key)
+- `echo_library_pypi` / `echo_library_npm` / `echo_library_maven` (bool, default: `false`)
+- `echo_library_key_name` / `echo_library_key_value` (string, sensitive) — library access key
+- `echo_pypi_url` (default: `"https://pypi.echohq.com"`)
+- `echo_npm_url` (default: `"https://npm.echohq.com"`)
+- `echo_maven_url` (default: `"https://maven.echohq.com"`)
+- `echo_pypi_repository_name` / `echo_npm_repository_name` / `echo_maven_repository_name`
+  (string, default: `""` → `<repository_name>-{pypi,npm,maven}`)
+- `maven_version_policy` (string, default: `"MIXED"`) / `maven_layout_policy` (string, default: `"PERMISSIVE"`)
+
+### Shared
+- `create` (bool, default: `true`)
+- `repository_name` (string, default: `"echo"`) — base name; per-format repos derive from it
+- `repository_online`, `blob_store_name`, `strict_content_type_validation`
+- `proxy_content_max_age`, `proxy_metadata_max_age`, `negative_cache_enabled`, `negative_cache_ttl`
+- `http_client_blocked`, `http_client_auto_block`, `connection_*`, `routing_rule`
+- Docker-only: `docker_force_basic_auth`, `docker_v1_enabled`, `docker_index_type`, `docker_index_url`
+- `create_content_selector`, `create_repository_privilege`, `tags`
+
+## Outputs
+- `usage_instructions` — per-format pull/install instructions (replace `<nexus-host>`)
+- `image_repository_key` — Docker proxy name (or `null`)
+- `library_repository_keys` — list of created library proxy names
+
+## Example — custom repository names
+
+```hcl
+module "echo_nexus_mirror" {
+  source = "./echo-terraform-nexus-mirror"
+
+  repository_name = "echo"
+
+  echo_images          = true
+  echo_image_key_name  = var.echo_image_key_name
+  echo_image_key_value = var.echo_image_key_value
+
+  echo_library_pypi         = true
+  echo_pypi_repository_name = "echo-python" # overrides the default "echo-pypi"
+  echo_library_key_name     = var.echo_library_key_name
+  echo_library_key_value    = var.echo_library_key_value
+}
+```
+
+## Provider Configuration
+```hcl
+provider "nexus" {
+  url      = "https://your-nexus-host"
+  username = var.nexus_username
+  password = var.nexus_password
+}
+```

--- a/echo-terraform-nexus-mirror/main.tf
+++ b/echo-terraform-nexus-mirror/main.tf
@@ -1,10 +1,27 @@
 # Terraform version requirements moved to versions.tf
 
+locals {
+  # Image key: prefer the new echo_image_key_*, fall back to the deprecated
+  # echo_access_key_* so existing image-only deployments keep working.
+  image_key_name  = var.echo_image_key_name != "" ? var.echo_image_key_name : var.echo_access_key_name
+  image_key_value = var.echo_image_key_value != "" ? var.echo_image_key_value : var.echo_access_key_value
+
+  # Provision the Docker proxy when explicitly enabled, or (legacy) when a
+  # deprecated access key was supplied.
+  create_docker = var.create && (var.echo_images || nonsensitive(var.echo_access_key_name) != "")
+
+  # Per-format repository keys (overridable, otherwise derived from the base).
+  image_repository = var.echo_image_repository_name != "" ? var.echo_image_repository_name : var.repository_name
+  pypi_repository  = var.echo_pypi_repository_name != "" ? var.echo_pypi_repository_name : "${var.repository_name}-pypi"
+  npm_repository   = var.echo_npm_repository_name != "" ? var.echo_npm_repository_name : "${var.repository_name}-npm"
+  maven_repository = var.echo_maven_repository_name != "" ? var.echo_maven_repository_name : "${var.repository_name}-maven"
+}
+
 # Docker proxy repository for Echo
 resource "nexus_repository_docker_proxy" "echo_proxy" {
-  count = var.create ? 1 : 0
+  count = local.create_docker ? 1 : 0
 
-  name   = var.repository_name
+  name   = local.image_repository
   online = var.repository_online
 
   # Docker configuration
@@ -52,8 +69,8 @@ resource "nexus_repository_docker_proxy" "echo_proxy" {
     # Authentication
     authentication {
       type        = "username"
-      username    = var.echo_access_key_name
-      password    = var.echo_access_key_value
+      username    = local.image_key_name
+      password    = local.image_key_value
       ntlm_host   = var.authentication_ntlm_host
       ntlm_domain = var.authentication_ntlm_domain
     }
@@ -71,6 +88,122 @@ resource "nexus_repository_docker_proxy" "echo_proxy" {
 }
 
 
+# PyPI proxy repository for Echo's PyPI index
+resource "nexus_repository_pypi_proxy" "echo_pypi" {
+  count = var.create && var.echo_library_pypi ? 1 : 0
+
+  name   = local.pypi_repository
+  online = var.repository_online
+
+  storage {
+    blob_store_name                = var.blob_store_name
+    strict_content_type_validation = var.strict_content_type_validation
+  }
+
+  proxy {
+    remote_url       = var.echo_pypi_url
+    content_max_age  = var.proxy_content_max_age
+    metadata_max_age = var.proxy_metadata_max_age
+  }
+
+  negative_cache {
+    enabled = var.negative_cache_enabled
+    ttl     = var.negative_cache_ttl
+  }
+
+  http_client {
+    blocked    = var.http_client_blocked
+    auto_block = var.http_client_auto_block
+
+    authentication {
+      type     = "username"
+      username = var.echo_library_key_name
+      password = var.echo_library_key_value
+    }
+  }
+
+  routing_rule = var.routing_rule
+}
+
+# npm proxy repository for Echo's npm index
+resource "nexus_repository_npm_proxy" "echo_npm" {
+  count = var.create && var.echo_library_npm ? 1 : 0
+
+  name   = local.npm_repository
+  online = var.repository_online
+
+  storage {
+    blob_store_name                = var.blob_store_name
+    strict_content_type_validation = var.strict_content_type_validation
+  }
+
+  proxy {
+    remote_url       = var.echo_npm_url
+    content_max_age  = var.proxy_content_max_age
+    metadata_max_age = var.proxy_metadata_max_age
+  }
+
+  negative_cache {
+    enabled = var.negative_cache_enabled
+    ttl     = var.negative_cache_ttl
+  }
+
+  http_client {
+    blocked    = var.http_client_blocked
+    auto_block = var.http_client_auto_block
+
+    authentication {
+      type     = "username"
+      username = var.echo_library_key_name
+      password = var.echo_library_key_value
+    }
+  }
+
+  routing_rule = var.routing_rule
+}
+
+# Maven proxy repository for Echo's Maven index
+resource "nexus_repository_maven_proxy" "echo_maven" {
+  count = var.create && var.echo_library_maven ? 1 : 0
+
+  name   = local.maven_repository
+  online = var.repository_online
+
+  maven {
+    version_policy = var.maven_version_policy
+    layout_policy  = var.maven_layout_policy
+  }
+
+  storage {
+    blob_store_name                = var.blob_store_name
+    strict_content_type_validation = var.strict_content_type_validation
+  }
+
+  proxy {
+    remote_url       = var.echo_maven_url
+    content_max_age  = var.proxy_content_max_age
+    metadata_max_age = var.proxy_metadata_max_age
+  }
+
+  negative_cache {
+    enabled = var.negative_cache_enabled
+    ttl     = var.negative_cache_ttl
+  }
+
+  http_client {
+    blocked    = var.http_client_blocked
+    auto_block = var.http_client_auto_block
+
+    authentication {
+      type     = "username"
+      username = var.echo_library_key_name
+      password = var.echo_library_key_value
+    }
+  }
+
+  routing_rule = var.routing_rule
+}
+
 # Optional: Create a content selector for the repository
 resource "nexus_security_content_selector" "echo_selector" {
   count = var.create && var.create_content_selector ? 1 : 0
@@ -80,9 +213,9 @@ resource "nexus_security_content_selector" "echo_selector" {
   expression  = var.content_selector_expression != "" ? var.content_selector_expression : "format == \"docker\" and path =~ \"^/v2/${var.repository_name}/.*\""
 }
 
-# Optional: Create repository privilege
+# Optional: Create repository privilege (Docker proxy only)
 resource "nexus_privilege_repository_view" "echo_privilege" {
-  count = var.create && var.create_repository_privilege ? 1 : 0
+  count = local.create_docker && var.create_repository_privilege ? 1 : 0
 
   name        = "${var.repository_name}-view"
   description = "View privilege for Echo Docker proxy repository"

--- a/echo-terraform-nexus-mirror/outputs.tf
+++ b/echo-terraform-nexus-mirror/outputs.tf
@@ -1,4 +1,23 @@
 output "usage_instructions" {
-  description = "Example Docker pull command"
-  value       = var.create ? "docker pull <nexus-host>${coalesce(var.docker_http_port, var.docker_https_port) != null ? ":${coalesce(var.docker_http_port, var.docker_https_port)}" : ""}/static:latest" : null
+  description = "Instructions for using the Echo proxy repositories provisioned in Nexus. Replace <nexus-host> with your Nexus host."
+  value = var.create ? join("\n", compact([
+    local.create_docker ? "Images:  docker pull <nexus-host>${coalesce(var.docker_http_port, var.docker_https_port) != null ? ":${coalesce(var.docker_http_port, var.docker_https_port)}" : ""}/static:latest" : "",
+    var.echo_library_pypi ? "PyPI:    pip install --index-url https://<nexus-host>/repository/${local.pypi_repository}/simple <package>" : "",
+    var.echo_library_npm ? "npm:     npm install --registry https://<nexus-host>/repository/${local.npm_repository}/ <package>" : "",
+    var.echo_library_maven ? "Maven:   add https://<nexus-host>/repository/${local.maven_repository} as a repository in your settings.xml" : "",
+  ])) : null
+}
+
+output "image_repository_key" {
+  description = "Name of the Docker proxy repository, if created."
+  value       = local.create_docker ? local.image_repository : null
+}
+
+output "library_repository_keys" {
+  description = "Names of the library proxy repositories that were created."
+  value = compact([
+    var.echo_library_pypi ? local.pypi_repository : "",
+    var.echo_library_npm ? local.npm_repository : "",
+    var.echo_library_maven ? local.maven_repository : "",
+  ])
 }

--- a/echo-terraform-nexus-mirror/variables.tf
+++ b/echo-terraform-nexus-mirror/variables.tf
@@ -13,20 +13,141 @@ variable "echo_registry_url" {
 
 variable "echo_access_key_name" {
   type        = string
-  description = "The name of the Echo access key - Get this from Echo platform"
+  description = "DEPRECATED: use echo_image_key_name. Kept for backwards compatibility with the original image-only module; when set it provisions the Docker proxy using the image fields."
   sensitive   = true
+  default     = ""
 }
 
 variable "echo_access_key_value" {
   type        = string
-  description = "The value of the Echo access key - Get this from Echo platform"
+  description = "DEPRECATED: use echo_image_key_value. Kept for backwards compatibility."
   sensitive   = true
+  default     = ""
+}
+
+# --- Images (container registry) ---
+variable "echo_images" {
+  type        = bool
+  description = "Provision the Docker proxy that mirrors Echo's image registry"
+  default     = false
+}
+
+variable "echo_image_key_name" {
+  type        = string
+  description = "Echo image access key name (username) for the Docker proxy - get this from the Echo platform"
+  sensitive   = true
+  default     = ""
+}
+
+variable "echo_image_key_value" {
+  type        = string
+  description = "Echo image access key value (password) for the Docker proxy - get this from the Echo platform"
+  sensitive   = true
+  default     = ""
+}
+
+variable "echo_image_repository_name" {
+  type        = string
+  description = "Override for the Docker proxy repository name. Defaults to repository_name."
+  default     = ""
+}
+
+# --- Libraries (package registries - one shared library key) ---
+variable "echo_library_pypi" {
+  type        = bool
+  description = "Provision the PyPI proxy that mirrors Echo's PyPI index"
+  default     = false
+}
+
+variable "echo_library_npm" {
+  type        = bool
+  description = "Provision the npm proxy that mirrors Echo's npm index"
+  default     = false
+}
+
+variable "echo_library_maven" {
+  type        = bool
+  description = "Provision the Maven proxy that mirrors Echo's Maven index"
+  default     = false
+}
+
+variable "echo_library_key_name" {
+  type        = string
+  description = "Echo library access key name (username) for the library proxies - get this from the Echo platform"
+  sensitive   = true
+  default     = ""
+}
+
+variable "echo_library_key_value" {
+  type        = string
+  description = "Echo library access key value (password) for the library proxies - get this from the Echo platform"
+  sensitive   = true
+  default     = ""
+}
+
+variable "echo_pypi_url" {
+  type        = string
+  description = "URL of the Echo PyPI index"
+  default     = "https://pypi.echohq.com"
+}
+
+variable "echo_npm_url" {
+  type        = string
+  description = "URL of the Echo npm index"
+  default     = "https://npm.echohq.com"
+}
+
+variable "echo_maven_url" {
+  type        = string
+  description = "URL of the Echo Maven index"
+  default     = "https://maven.echohq.com"
+}
+
+variable "echo_pypi_repository_name" {
+  type        = string
+  description = "Override for the PyPI proxy repository name. Defaults to <repository_name>-pypi."
+  default     = ""
+}
+
+variable "echo_npm_repository_name" {
+  type        = string
+  description = "Override for the npm proxy repository name. Defaults to <repository_name>-npm."
+  default     = ""
+}
+
+variable "echo_maven_repository_name" {
+  type        = string
+  description = "Override for the Maven proxy repository name. Defaults to <repository_name>-maven."
+  default     = ""
+}
+
+# Maven proxy policies (datadrivers/nexus requires an explicit maven block)
+variable "maven_version_policy" {
+  type        = string
+  description = "Maven version policy (RELEASE, SNAPSHOT, or MIXED)"
+  default     = "MIXED"
+
+  validation {
+    condition     = contains(["RELEASE", "SNAPSHOT", "MIXED"], var.maven_version_policy)
+    error_message = "Maven version policy must be one of: RELEASE, SNAPSHOT, or MIXED."
+  }
+}
+
+variable "maven_layout_policy" {
+  type        = string
+  description = "Maven layout policy (STRICT or PERMISSIVE)"
+  default     = "PERMISSIVE"
+
+  validation {
+    condition     = contains(["STRICT", "PERMISSIVE"], var.maven_layout_policy)
+    error_message = "Maven layout policy must be one of: STRICT or PERMISSIVE."
+  }
 }
 
 # Repository Configuration
 variable "repository_name" {
   type        = string
-  description = "Name of the Docker proxy repository"
+  description = "Base name for the proxy repositories. Per-format repos derive from it (<name>, <name>-pypi, <name>-npm, <name>-maven) unless overridden."
   default     = "echo"
 
   validation {


### PR DESCRIPTION
## What

Extends `echo-terraform-nexus-mirror` beyond the Docker proxy to mirror **libraries** (PyPI / npm / Maven), matching the multi-artifact integration contract (ECH-5246) and the steps rendered in the platform Integrations UI. Mirrors the JFrog work (onboarding-providers#7).

## Changes

- **Images:** `echo_images` + `echo_image_key_{name,value}` provision the Docker proxy.
- **Libraries:** `echo_library_{pypi,npm,maven}` + a shared `echo_library_key_{name,value}` provision `nexus_repository_{pypi,npm,maven}_proxy`, each created only when flagged.
- **Endpoints** default to `pypi/npm/maven.echohq.com`, overridable.
- **Optional per-format repository-name overrides** (same pattern as images): base `echo` → `echo-pypi`/`echo-npm`/`echo-maven`, each overridable.
- **Maven** gets `maven_version_policy` (default `MIXED`) + `maven_layout_policy` (default `PERMISSIVE`), required by the `datadrivers/nexus` proxy resource.
- **Backwards-compatible:** the deprecated `echo_access_key_{name,value}` still provisions the Docker proxy; the `nexus_repository_docker_proxy.echo_proxy` resource address is unchanged → no state churn for existing image-only deployments.

## Outputs

- `usage_instructions` — per-format pull/install commands.
- `image_repository_key` — Docker proxy name (or `null`).
- `library_repository_keys` — created library proxy names.

## Notes

- **No Pulumi:** there is no first-class Nexus Pulumi provider, and the Integrations UI offers Nexus via **Terraform + Manual** only. Pulumi is deferred (tracked under ECH-5266's Pulumi sub-scope).

## Verification

- `terraform fmt -check` ✓
- `terraform validate` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Docker provisioning is triggered (opt-in unless legacy keys are set) and adds new Nexus proxies that store Echo library credentials; backward compatibility is intentional but callers must adopt new flags for greenfield Docker setups.
> 
> **Overview**
> Extends **`echo-terraform-nexus-mirror`** from a Docker-only Echo proxy to optional **PyPI, npm, and Maven** library mirrors, aligned with the multi-artifact integration contract.
> 
> **Docker (images)** is gated by `echo_images` and `echo_image_key_*`, with optional `echo_image_repository_name`. Legacy **`echo_access_key_*`** still creates the same `nexus_repository_docker_proxy.echo_proxy` resource when set, so existing image-only state should not churn. **Libraries** use per-format flags (`echo_library_pypi` / `npm` / `maven`), a shared `echo_library_key_*`, default Echo upstream URLs, derived repo names (`<base>-pypi`, etc.) with overrides, and Maven `version_policy` / `layout_policy`.
> 
> **Outputs** now include multi-line `usage_instructions`, `image_repository_key`, and `library_repository_keys`. README examples rename the module to `echo_nexus_mirror` and document the new inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeba0f9e053db2e2e22ec60bfd96248000458e6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->