### PR TITLE
[ECH-5264] feat(gar): library mirror support (PyPI/npm/maven)

### DIFF
--- a/echo-pulumi-gar-mirror/README.md
+++ b/echo-pulumi-gar-mirror/README.md
@@ -1,6 +1,10 @@
 # Echo GAR Remote Repository - Pulumi Component
 
-Purpose: Minimal Pulumi component to set up a GCP Artifact Registry remote repository for Echo.
+Configures GCP Artifact Registry as a proxy for Echo. One component provisions a
+Docker remote for **images** and/or PyPI (PYTHON) / npm (NPM) / Maven (MAVEN)
+remotes for **libraries**, based on the inputs. Each repository is created only
+when its flag is set. Credentials are stored in Secret Manager; the image key
+and the library key are distinct secrets.
 
 ## Install
 ```bash
@@ -13,37 +17,64 @@ import { GcpGarRemote } from "@buildecho/echo-pulumi-gar-mirror";
 
 const remote = new GcpGarRemote("echo-remote", {
   projectId: "my-gcp-project",
-  location: "us-central1",         // default
-  cacheRepositoryName: "echo",     // default
-  echoAccessKeyName: "<echo-username>",
-  echoAccessKeyValue: "<echo-password>",
-  echoRegistryUrl: "https://reg.echohq.com" // default
+
+  // Images
+  echoImages: true,
+  echoImageKeyName: config.requireSecret("echoImageKeyName"),
+  echoImageKeyValue: config.requireSecret("echoImageKeyValue"),
+
+  // Libraries (one shared library key)
+  echoLibraryPypi: true,
+  echoLibraryNpm: true,
+  echoLibraryKeyName: config.requireSecret("echoLibraryKeyName"),
+  echoLibraryKeyValue: config.requireSecret("echoLibraryKeyValue"),
 });
 
 export const usage = remote.usageInstructions;
 ```
 
 ## Inputs
+
+### Images (container registry)
+- `echoImages` (boolean, default: `false`) — provision the Docker remote
+- `echoImageKeyName` / `echoImageKeyValue` (Input<string>, secret) — image access key
+- `echoImageRepositoryName` (string, default: `""` → `repositoryName`)
+- `echoRegistryUrl` (string, default: `https://reg.echohq.com`)
+- `echoAccessKeySecretName` (string, default: `echo-gar-mirror-secret`) — Secret Manager secret name for the image key
+- `echoAccessKeyName` / `echoAccessKeyValue` — **deprecated**, kept for backwards
+  compatibility; provisions the Docker remote when set.
+
+### Libraries (package registries — one shared library key)
+- `echoLibraryPypi` / `echoLibraryNpm` / `echoLibraryMaven` (boolean, default: `false`)
+- `echoLibraryKeyName` / `echoLibraryKeyValue` (Input<string>, secret) — library access key
+- `echoLibraryKeySecretName` (string, default: `echo-gar-mirror-library-secret`) — Secret Manager secret name for the library key
+- `echoPypiUrl` (default: `https://pypi.echohq.com`)
+- `echoNpmUrl` (default: `https://npm.echohq.com`)
+- `echoMavenUrl` (default: `https://maven.echohq.com`)
+- `echoPypiRepositoryName` / `echoNpmRepositoryName` / `echoMavenRepositoryName`
+  (string, default: `""` → `<repositoryName>-{pypi,npm,maven}`)
+
+### Shared
 - `projectId` (string, required)
 - `location` (string, default: `us-central1`)
-- `repositoryName` (string, default: `echo`)
-- `echoAccessKeyName` (string, required)
-- `echoAccessKeyValue` (string, required, secret)
-- `echoRegistryUrl` (string, default: `https://reg.echohq.com`)
+- `repositoryName` (string, default: `echo`) — base name; per-format repos derive from it
 - `description` (string, default: `Remote repository for Echo Registry integration`)
-- `readerMembers` (string[], optional)
-- `writerMembers` (string[], optional)
-- `echoAccessKeySecretName` (string, default: `echo-gar-mirror-secret`)
+- `readerMembers` (string[], optional) — granted reader on every created repo
+- `writerMembers` (string[], optional) — granted writer on every created repo
 - `labels` (Record<string, string>, optional)
 
 ## Outputs
-- `repositoryId`: GAR repository id
-- `secretId`: Secret Manager secret id
-- `secretVersionName`: Secret version name
-- `usageInstructions`: Single-line docker pull command template
+- `imageRepositoryKey`: Docker remote repository id (or `undefined`)
+- `libraryRepositoryKeys`: list of created library remote repository ids
+- `usageInstructions`: multi-line per-format pull/install instructions
 
 ## Test
 ```bash
-gcloud auth configure-docker us-central1-docker.pkg.dev
-docker pull us-central1-docker.pkg.dev/<PROJECT>/<REPOSITORY>/<echo-image>:<tag>
+# Images
+gcloud auth configure-docker <location>-docker.pkg.dev
+docker pull <location>-docker.pkg.dev/<PROJECT>/<REPOSITORY>/<echo-image>:<tag>
+
+# Libraries (examples)
+pip install --index-url https://<location>-python.pkg.dev/<PROJECT>/<REPOSITORY>-pypi/simple/ <package>
+npm install --registry https://<location>-npm.pkg.dev/<PROJECT>/<REPOSITORY>-npm/ <package>
 ```

--- a/echo-pulumi-gar-mirror/index.ts
+++ b/echo-pulumi-gar-mirror/index.ts
@@ -3,6 +3,11 @@ import * as gcp from "@pulumi/gcp";
 
 /**
  * Configuration options for the GCP Artifact Registry Remote Repository
+ *
+ * One component orchestrates the image (DOCKER) remote and the library
+ * (PYTHON / NPM / MAVEN) remotes; each is provisioned only when its flag is
+ * set. Images use the image access key, libraries share the library access key.
+ * Credentials are stored in Secret Manager.
  */
 export interface GcpGarRemoteInput {
 
@@ -10,60 +15,116 @@ export interface GcpGarRemoteInput {
      * The GCP project ID where resources will be created
      */
     projectId: string;
-    
+
     /**
-     * The location for the Artifact Registry repository
+     * The location for the Artifact Registry repositories
      * @default "us-central1"
      */
     location?: string;
-    
+
     /**
-     * Repository name for cached images - This will be the name of your repository
+     * Base repository name. Per-format repositories derive from it
+     * (<name>, <name>-pypi, <name>-npm, <name>-maven) unless overridden.
      * @default "echo"
      */
     repositoryName?: string;
-    
+
     /**
-     * Echo access key name (username)
-     */
-    echoAccessKeyName: pulumi.Input<string>;
-    
-    /**
-     * Echo access key value (password/token)
-     */
-    echoAccessKeyValue: pulumi.Input<string>;
-    
-    /**
-     * Echo registry URL
-     * @default "https://reg.echohq.com"
-     */
-    echoRegistryUrl?: string;
-    
-    /**
-     * Description for the repository
+     * Description for the repositories
      * @default "Remote repository for Echo Registry integration"
      */
     description?: string;
-    
+
+    // --- Images (container registry) ---
+
+    /** Provision the Docker remote that proxies Echo's image registry. */
+    echoImages?: boolean;
+
+    /** Echo image access key name (username) for the Docker remote. */
+    echoImageKeyName?: pulumi.Input<string>;
+
+    /** Echo image access key value (password) for the Docker remote. */
+    echoImageKeyValue?: pulumi.Input<string>;
+
+    /** Optional override for the Docker remote repository id. Defaults to repositoryName. */
+    echoImageRepositoryName?: string;
+
     /**
-     * List of members who should have reader access to the repository
+     * Echo image registry URL
+     * @default "https://reg.echohq.com"
+     */
+    echoRegistryUrl?: string;
+
+    /**
+     * @deprecated Use echoImageKeyName. Kept for backwards compatibility with the
+     * original image-only component; provisions the Docker remote when set.
+     */
+    echoAccessKeyName?: pulumi.Input<string>;
+
+    /** @deprecated Use echoImageKeyValue. */
+    echoAccessKeyValue?: pulumi.Input<string>;
+
+    /**
+     * Secret Manager secret name for the Echo image access key.
+     * @default "echo-gar-mirror-secret"
+     */
+    echoAccessKeySecretName?: string;
+
+    // --- Libraries (package registries), one shared library key ---
+
+    /** Provision the PyPI (PYTHON) remote that proxies Echo's PyPI index. */
+    echoLibraryPypi?: boolean;
+
+    /** Provision the npm (NPM) remote that proxies Echo's npm index. */
+    echoLibraryNpm?: boolean;
+
+    /** Provision the Maven (MAVEN) remote that proxies Echo's Maven index. */
+    echoLibraryMaven?: boolean;
+
+    /** Echo library access key name (username) for the library remotes. */
+    echoLibraryKeyName?: pulumi.Input<string>;
+
+    /** Echo library access key value (password) for the library remotes. */
+    echoLibraryKeyValue?: pulumi.Input<string>;
+
+    /**
+     * Secret Manager secret name for the Echo library access key.
+     * @default "echo-gar-mirror-library-secret"
+     */
+    echoLibraryKeySecretName?: string;
+
+    /** @default "https://pypi.echohq.com" */
+    echoPypiUrl?: string;
+
+    /** @default "https://npm.echohq.com" */
+    echoNpmUrl?: string;
+
+    /** @default "https://maven.echohq.com" */
+    echoMavenUrl?: string;
+
+    /** Optional override for the PyPI remote repository id. Defaults to <name>-pypi. */
+    echoPypiRepositoryName?: string;
+
+    /** Optional override for the npm remote repository id. Defaults to <name>-npm. */
+    echoNpmRepositoryName?: string;
+
+    /** Optional override for the Maven remote repository id. Defaults to <name>-maven. */
+    echoMavenRepositoryName?: string;
+
+    // --- IAM ---
+
+    /**
+     * List of members who should have reader access to the created repositories.
      * Format: "user:email@example.com", "serviceAccount:sa@project.iam.gserviceaccount.com", etc.
      */
     readerMembers?: string[];
-    
+
     /**
-     * List of members who should have writer access to the repository
+     * List of members who should have writer access to the created repositories.
      * Format: "user:email@example.com", "serviceAccount:sa@project.iam.gserviceaccount.com", etc.
      */
     writerMembers?: string[];
 
-
-    /**
-     * Name for the secret that will be created.
-     * @default "echo-gar-mirror-secret"
-     */
-    echoAccessKeySecretName?: string;
-    
     /**
      * Additional labels to apply to created resources
      */
@@ -75,157 +136,282 @@ export interface GcpGarRemoteInput {
  */
 export interface GcpGarRemoteOutputs {
     /**
-     * The repository ID
+     * Repository id of the Docker (image) remote, or undefined if not created.
      */
-    repositoryId: pulumi.Output<string>;
-    
-    
+    imageRepositoryKey: pulumi.Output<string | undefined>;
+
     /**
-     * The secret ID storing Echo credentials
+     * Repository ids of the library remotes that were created.
      */
-    secretId: pulumi.Output<string>;
-    
+    libraryRepositoryKeys: pulumi.Output<string[]>;
+
     /**
-     * The secret version name
-     */
-    secretVersionName: pulumi.Output<string>;
-    
-    /**
-     * Single-line usage instructions
+     * Multi-line usage instructions for the created repositories.
      */
     usageInstructions: pulumi.Output<string>;
 }
 
 /**
  * GCP Artifact Registry Remote Repository Component
- * 
- * This component sets up a GCP Artifact Registry remote repository that points to Echo's registry,
- * allowing you to pull Echo images through GCP's Artifact Registry.
- * 
+ *
+ * Provisions GCP Artifact Registry remote repositories that proxy Echo — a
+ * Docker remote for images and PYTHON/NPM/MAVEN remotes for libraries — based
+ * on the inputs. Credentials are stored in Secret Manager.
+ *
  * @example
  * ```typescript
  * import { GcpGarRemote } from "@buildecho/echo-pulumi-gar-mirror";
- * 
+ *
  * const echoRemote = new GcpGarRemote("echo-remote", {
  *     projectId: "my-gcp-project",
- *     echoAccessKeyName: config.requireSecret("echoAccessKeyName"),
- *     echoAccessKeyValue: config.requireSecret("echoAccessKeyValue"),
- *     readerMembers: ["user:developer@example.com"]
+ *     echoImages: true,
+ *     echoImageKeyName: config.requireSecret("echoImageKeyName"),
+ *     echoImageKeyValue: config.requireSecret("echoImageKeyValue"),
+ *     echoLibraryPypi: true,
+ *     echoLibraryKeyName: config.requireSecret("echoLibraryKeyName"),
+ *     echoLibraryKeyValue: config.requireSecret("echoLibraryKeyValue"),
  * });
- * 
+ *
  * export const usage = echoRemote.usageInstructions;
  * ```
  */
 export class GcpGarRemote extends pulumi.ComponentResource {
-    public readonly repositoryId: pulumi.Output<string>;
-    public readonly secretId: pulumi.Output<string>;
-    public readonly secretVersionName: pulumi.Output<string>;
+    public readonly imageRepositoryKey: pulumi.Output<string | undefined>;
+    public readonly libraryRepositoryKeys: pulumi.Output<string[]>;
     public readonly usageInstructions: pulumi.Output<string>;
-    
+
     constructor(name: string, args: GcpGarRemoteInput, opts?: pulumi.ComponentResourceOptions) {
         super("echo-pulumi-gar-mirror:index:GcpGarRemote", name, args, opts);
-        
+
         // Set defaults
         const location = args.location || "us-central1";
         const repositoryName = args.repositoryName || "echo";
-        const echoRegistryUrl = args.echoRegistryUrl || "https://reg.echohq.com";
         const description = args.description || "Remote repository for Echo Registry integration";
-        const secretName = args.echoAccessKeySecretName || "echo-gar-mirror-secret";
-        
+        const imageSecretName = args.echoAccessKeySecretName || "echo-gar-mirror-secret";
+        const librarySecretName = args.echoLibraryKeySecretName || "echo-gar-mirror-library-secret";
+
         const labels = { ...args.labels };
-        
+
         // Get current project info
         const project = gcp.organizations.getProject({
             projectId: args.projectId,
         });
-        
-        // Create Secret Manager secret for Echo access key
-        const secret = new gcp.secretmanager.Secret(`${name}-echo-access-key`, {
-            secretId: secretName,
-            replication: {
-                auto: {},
-            },
-            labels: {
-                ...labels,
-                purpose: "echo-registry-authentication",
-            },
-            project: args.projectId,
-        }, { parent: this });
-        
-        // Create secret version with the Echo access key value
-        const echoAccessKeySecretVersion = new gcp.secretmanager.SecretVersion(`${name}-echo-access-key-version`, {
-            secret: secret.id,
-            secretData: args.echoAccessKeyValue,
-        }, { parent: this });
-        
-        // Create Artifact Registry remote repository
-        const repository = new gcp.artifactregistry.Repository(`${name}-remote-repo`, {
-            repositoryId: repositoryName,
-            location: location,
-            format: "DOCKER",
-            mode: "REMOTE_REPOSITORY",
-            description: description,
-            remoteRepositoryConfig: {
-                description: "Remote repository pointing to Echo Registry (reg.echohq.com)",
-                dockerRepository: {
-                    customRepository: {
-                        uri: echoRegistryUrl,
-                    },
+
+        const garServiceAccount = pulumi.interpolate`serviceAccount:service-${project.then(p => p.number)}@gcp-sa-artifactregistry.iam.gserviceaccount.com`;
+
+        const createdRepositories: gcp.artifactregistry.Repository[] = [];
+        const instructions: string[] = [];
+
+        // --- Image (Docker) remote ---
+        // Provision when explicitly enabled, or (legacy) when a deprecated access
+        // key was supplied. Image key prefers the new field, falls back to access.
+        const createDocker = args.echoImages === true || args.echoAccessKeyName !== undefined;
+        if (createDocker) {
+            const imageRepository = args.echoImageRepositoryName || repositoryName;
+
+            // Create Secret Manager secret for the Echo image access key
+            const secret = new gcp.secretmanager.Secret(`${name}-echo-access-key`, {
+                secretId: imageSecretName,
+                replication: {
+                    auto: {},
                 },
-                upstreamCredentials: {
-                    usernamePasswordCredentials: {
-                        username: args.echoAccessKeyName,
-                        passwordSecretVersion: echoAccessKeySecretVersion.name,
-                    },
+                labels: {
+                    ...labels,
+                    purpose: "echo-registry-authentication",
                 },
-            },
-            labels: labels,
-            project: args.projectId,
-        }, { parent: this });
-        
-        // Grant GAR service account access to the secret
-         new gcp.secretmanager.SecretIamMember(`${name}-gar-secret-accessor`, {
-            secretId: secret.secretId,
-            role: "roles/secretmanager.secretAccessor",
-            member: pulumi.interpolate`serviceAccount:service-${project.then(p => p.number)}@gcp-sa-artifactregistry.iam.gserviceaccount.com`,
-            project: args.projectId,
-        }, { parent: this });
-        
-        // Create IAM bindings for repository readers if specified
-        if (args.readerMembers && args.readerMembers.length > 0) {
-            new gcp.artifactregistry.RepositoryIamBinding(`${name}-readers`, {
-                repository: repository.name,
-                location: repository.location,
-                role: "roles/artifactregistry.reader",
-                members: args.readerMembers,
                 project: args.projectId,
             }, { parent: this });
-        }
-        
-        // Create IAM bindings for repository writers if specified
-        if (args.writerMembers && args.writerMembers.length > 0) {
-            new gcp.artifactregistry.RepositoryIamBinding(`${name}-writers`, {
-                repository: repository.name,
-                location: repository.location,
-                role: "roles/artifactregistry.writer",
-                members: args.writerMembers,
+
+            const echoAccessKeySecretVersion = new gcp.secretmanager.SecretVersion(`${name}-echo-access-key-version`, {
+                secret: secret.id,
+                secretData: args.echoImageKeyValue ?? args.echoAccessKeyValue ?? "",
+            }, { parent: this });
+
+            const repository = new gcp.artifactregistry.Repository(`${name}-remote-repo`, {
+                repositoryId: imageRepository,
+                location: location,
+                format: "DOCKER",
+                mode: "REMOTE_REPOSITORY",
+                description: description,
+                remoteRepositoryConfig: {
+                    description: "Remote repository pointing to Echo Registry (reg.echohq.com)",
+                    dockerRepository: {
+                        customRepository: {
+                            uri: args.echoRegistryUrl || "https://reg.echohq.com",
+                        },
+                    },
+                    upstreamCredentials: {
+                        usernamePasswordCredentials: {
+                            username: args.echoImageKeyName ?? args.echoAccessKeyName ?? "",
+                            passwordSecretVersion: echoAccessKeySecretVersion.name,
+                        },
+                    },
+                },
+                labels: labels,
                 project: args.projectId,
             }, { parent: this });
+
+            // Grant the GAR service account access to the image secret
+            new gcp.secretmanager.SecretIamMember(`${name}-gar-secret-accessor`, {
+                secretId: secret.secretId,
+                role: "roles/secretmanager.secretAccessor",
+                member: garServiceAccount,
+                project: args.projectId,
+            }, { parent: this });
+
+            createdRepositories.push(repository);
+            this.imageRepositoryKey = repository.repositoryId;
+            instructions.push(`Images:  docker pull ${location}-docker.pkg.dev/${args.projectId}/${imageRepository}/static:latest`);
+        } else {
+            this.imageRepositoryKey = pulumi.output(undefined);
         }
 
-        const repositoryUrl = pulumi.interpolate`${location}-docker.pkg.dev/${args.projectId}/${repository.repositoryId}`;
-        
+        // --- Library remotes (one shared library key) ---
+        const createLibrary = args.echoLibraryPypi === true || args.echoLibraryNpm === true || args.echoLibraryMaven === true;
+        const libraryRepositoryKeys: pulumi.Output<string>[] = [];
+
+        if (createLibrary) {
+            const librarySecret = new gcp.secretmanager.Secret(`${name}-echo-library-key`, {
+                secretId: librarySecretName,
+                replication: {
+                    auto: {},
+                },
+                labels: {
+                    ...labels,
+                    purpose: "echo-library-authentication",
+                },
+                project: args.projectId,
+            }, { parent: this });
+
+            const librarySecretVersion = new gcp.secretmanager.SecretVersion(`${name}-echo-library-key-version`, {
+                secret: librarySecret.id,
+                secretData: args.echoLibraryKeyValue ?? "",
+            }, { parent: this });
+
+            // Grant the GAR service account access to the library secret
+            new gcp.secretmanager.SecretIamMember(`${name}-gar-library-secret-accessor`, {
+                secretId: librarySecret.secretId,
+                role: "roles/secretmanager.secretAccessor",
+                member: garServiceAccount,
+                project: args.projectId,
+            }, { parent: this });
+
+            const libraryUpstreamCredentials = {
+                usernamePasswordCredentials: {
+                    username: args.echoLibraryKeyName ?? "",
+                    passwordSecretVersion: librarySecretVersion.name,
+                },
+            };
+
+            if (args.echoLibraryPypi) {
+                const key = args.echoPypiRepositoryName || `${repositoryName}-pypi`;
+                const repository = new gcp.artifactregistry.Repository(`${name}-pypi`, {
+                    repositoryId: key,
+                    location: location,
+                    format: "PYTHON",
+                    mode: "REMOTE_REPOSITORY",
+                    description: description,
+                    remoteRepositoryConfig: {
+                        description: "Remote repository pointing to Echo PyPI (pypi.echohq.com)",
+                        pythonRepository: {
+                            customRepository: {
+                                uri: args.echoPypiUrl || "https://pypi.echohq.com",
+                            },
+                        },
+                        upstreamCredentials: libraryUpstreamCredentials,
+                    },
+                    labels: labels,
+                    project: args.projectId,
+                }, { parent: this });
+                createdRepositories.push(repository);
+                libraryRepositoryKeys.push(repository.repositoryId);
+                instructions.push(`PyPI:    pip install --index-url https://${location}-python.pkg.dev/${args.projectId}/${key}/simple/ <package>`);
+            }
+
+            if (args.echoLibraryNpm) {
+                const key = args.echoNpmRepositoryName || `${repositoryName}-npm`;
+                const repository = new gcp.artifactregistry.Repository(`${name}-npm`, {
+                    repositoryId: key,
+                    location: location,
+                    format: "NPM",
+                    mode: "REMOTE_REPOSITORY",
+                    description: description,
+                    remoteRepositoryConfig: {
+                        description: "Remote repository pointing to Echo npm (npm.echohq.com)",
+                        npmRepository: {
+                            customRepository: {
+                                uri: args.echoNpmUrl || "https://npm.echohq.com",
+                            },
+                        },
+                        upstreamCredentials: libraryUpstreamCredentials,
+                    },
+                    labels: labels,
+                    project: args.projectId,
+                }, { parent: this });
+                createdRepositories.push(repository);
+                libraryRepositoryKeys.push(repository.repositoryId);
+                instructions.push(`npm:     npm install --registry https://${location}-npm.pkg.dev/${args.projectId}/${key}/ <package>`);
+            }
+
+            if (args.echoLibraryMaven) {
+                const key = args.echoMavenRepositoryName || `${repositoryName}-maven`;
+                const repository = new gcp.artifactregistry.Repository(`${name}-maven`, {
+                    repositoryId: key,
+                    location: location,
+                    format: "MAVEN",
+                    mode: "REMOTE_REPOSITORY",
+                    description: description,
+                    remoteRepositoryConfig: {
+                        description: "Remote repository pointing to Echo Maven (maven.echohq.com)",
+                        mavenRepository: {
+                            customRepository: {
+                                uri: args.echoMavenUrl || "https://maven.echohq.com",
+                            },
+                        },
+                        upstreamCredentials: libraryUpstreamCredentials,
+                    },
+                    labels: labels,
+                    project: args.projectId,
+                }, { parent: this });
+                createdRepositories.push(repository);
+                libraryRepositoryKeys.push(repository.repositoryId);
+                instructions.push(`Maven:   add https://${location}-maven.pkg.dev/${args.projectId}/${key} as a repository in your settings.xml`);
+            }
+        }
+
+        // Create IAM bindings for repository readers/writers across all created repos
+        if (args.readerMembers && args.readerMembers.length > 0) {
+            createdRepositories.forEach((repository, i) => {
+                new gcp.artifactregistry.RepositoryIamBinding(`${name}-readers-${i}`, {
+                    repository: repository.name,
+                    location: repository.location,
+                    role: "roles/artifactregistry.reader",
+                    members: args.readerMembers!,
+                    project: args.projectId,
+                }, { parent: this });
+            });
+        }
+
+        if (args.writerMembers && args.writerMembers.length > 0) {
+            createdRepositories.forEach((repository, i) => {
+                new gcp.artifactregistry.RepositoryIamBinding(`${name}-writers-${i}`, {
+                    repository: repository.name,
+                    location: repository.location,
+                    role: "roles/artifactregistry.writer",
+                    members: args.writerMembers!,
+                    project: args.projectId,
+                }, { parent: this });
+            });
+        }
+
         // Set outputs
-        this.repositoryId = repository.repositoryId;
-        this.secretId = secret.secretId;
-        this.secretVersionName = echoAccessKeySecretVersion.name;
-        this.usageInstructions = pulumi.interpolate`docker pull ${repositoryUrl}/static:latest`;
-        
+        this.libraryRepositoryKeys = pulumi.all(libraryRepositoryKeys);
+        this.usageInstructions = pulumi.output(instructions.join("\n"));
+
         // Register outputs
         this.registerOutputs({
-            repositoryId: this.repositoryId,
-            secretId: this.secretId,
-            secretVersionName: this.secretVersionName,
+            imageRepositoryKey: this.imageRepositoryKey,
+            libraryRepositoryKeys: this.libraryRepositoryKeys,
             usageInstructions: this.usageInstructions,
         });
     }

--- a/echo-pulumi-gar-mirror/index.ts
+++ b/echo-pulumi-gar-mirror/index.ts
@@ -149,6 +149,24 @@ export interface GcpGarRemoteOutputs {
      * Multi-line usage instructions for the created repositories.
      */
     usageInstructions: pulumi.Output<string>;
+
+    /**
+     * @deprecated Use imageRepositoryKey. Repository id of the Docker (image)
+     * remote, kept for backwards compatibility with the image-only module.
+     */
+    repositoryId: pulumi.Output<string | undefined>;
+
+    /**
+     * @deprecated Secret id of the Echo image access key secret, kept for
+     * backwards compatibility with the image-only module.
+     */
+    secretId: pulumi.Output<string | undefined>;
+
+    /**
+     * @deprecated Full resource name of the image secret version, kept for
+     * backwards compatibility with the image-only module.
+     */
+    secretVersionName: pulumi.Output<string | undefined>;
 }
 
 /**
@@ -179,6 +197,12 @@ export class GcpGarRemote extends pulumi.ComponentResource {
     public readonly imageRepositoryKey: pulumi.Output<string | undefined>;
     public readonly libraryRepositoryKeys: pulumi.Output<string[]>;
     public readonly usageInstructions: pulumi.Output<string>;
+    /** @deprecated Use imageRepositoryKey. */
+    public readonly repositoryId: pulumi.Output<string | undefined>;
+    /** @deprecated Image secret id, kept for backwards compatibility. */
+    public readonly secretId: pulumi.Output<string | undefined>;
+    /** @deprecated Image secret version name, kept for backwards compatibility. */
+    public readonly secretVersionName: pulumi.Output<string | undefined>;
 
     constructor(name: string, args: GcpGarRemoteInput, opts?: pulumi.ComponentResourceOptions) {
         super("echo-pulumi-gar-mirror:index:GcpGarRemote", name, args, opts);
@@ -261,9 +285,15 @@ export class GcpGarRemote extends pulumi.ComponentResource {
 
             createdRepositories.push(repository);
             this.imageRepositoryKey = repository.repositoryId;
+            this.repositoryId = repository.repositoryId;
+            this.secretId = secret.secretId;
+            this.secretVersionName = echoAccessKeySecretVersion.name;
             instructions.push(`Images:  docker pull ${location}-docker.pkg.dev/${args.projectId}/${imageRepository}/static:latest`);
         } else {
             this.imageRepositoryKey = pulumi.output(undefined);
+            this.repositoryId = pulumi.output(undefined);
+            this.secretId = pulumi.output(undefined);
+            this.secretVersionName = pulumi.output(undefined);
         }
 
         // --- Library remotes (one shared library key) ---
@@ -379,10 +409,14 @@ export class GcpGarRemote extends pulumi.ComponentResource {
             }
         }
 
-        // Create IAM bindings for repository readers/writers across all created repos
+        // Create IAM bindings for repository readers/writers across all created
+        // repos. The first repo (the image remote, index 0) keeps the unindexed
+        // logical name it had in the image-only module so existing deployments
+        // don't replace their bindings; additional repos are suffixed.
+        const bindingSuffix = (i: number) => (i === 0 ? "" : `-${i}`);
         if (args.readerMembers && args.readerMembers.length > 0) {
             createdRepositories.forEach((repository, i) => {
-                new gcp.artifactregistry.RepositoryIamBinding(`${name}-readers-${i}`, {
+                new gcp.artifactregistry.RepositoryIamBinding(`${name}-readers${bindingSuffix(i)}`, {
                     repository: repository.name,
                     location: repository.location,
                     role: "roles/artifactregistry.reader",
@@ -394,7 +428,7 @@ export class GcpGarRemote extends pulumi.ComponentResource {
 
         if (args.writerMembers && args.writerMembers.length > 0) {
             createdRepositories.forEach((repository, i) => {
-                new gcp.artifactregistry.RepositoryIamBinding(`${name}-writers-${i}`, {
+                new gcp.artifactregistry.RepositoryIamBinding(`${name}-writers${bindingSuffix(i)}`, {
                     repository: repository.name,
                     location: repository.location,
                     role: "roles/artifactregistry.writer",
@@ -413,6 +447,9 @@ export class GcpGarRemote extends pulumi.ComponentResource {
             imageRepositoryKey: this.imageRepositoryKey,
             libraryRepositoryKeys: this.libraryRepositoryKeys,
             usageInstructions: this.usageInstructions,
+            repositoryId: this.repositoryId,
+            secretId: this.secretId,
+            secretVersionName: this.secretVersionName,
         });
     }
 }

--- a/echo-terraform-gar-mirror/README.md
+++ b/echo-terraform-gar-mirror/README.md
@@ -1,61 +1,107 @@
 # Echo GAR Remote Repository - Terraform Module
 
-Purpose: Minimal GAR remote repository to integrate with the Echo registry.
+Configures Google Artifact Registry as a proxy for Echo. One module provisions a
+Docker remote for **images** and/or PyPI (PYTHON) / npm (NPM) / Maven (MAVEN)
+remotes for **libraries**, based on the inputs. Each repository is created only
+when its flag is set. Credentials are stored in Secret Manager; the image key
+and the library key are distinct secrets.
 
 ## Quickstart
 
 ```hcl
-module "echo_gar_remote" {
+module "echo_gar_mirror" {
   source = "git@github.com:buildecho/onboarding-providers.git//echo-terraform-gar-mirror"
 
-  project_id            = "my-gcp-project"
-  echo_access_key_name  = "my-echo-key-name"
-  echo_access_key_value = "my-echo-key-value"
-  # location and cache_repository_name default to "us-central1" and "echo"
+  project_id = "my-gcp-project"
+
+  # Images
+  echo_images          = true
+  echo_image_key_name  = var.echo_image_key_name
+  echo_image_key_value = var.echo_image_key_value
+
+  # Libraries (one shared library key)
+  echo_library_pypi      = true
+  echo_library_npm       = true
+  echo_library_key_name  = var.echo_library_key_name
+  echo_library_key_value = var.echo_library_key_value
+}
+
+output "usage_instructions" {
+  value = module.echo_gar_mirror.usage_instructions
 }
 ```
 
 ```bash
-terraform init && terraform apply -auto-approve
+terraform init && terraform apply
 ```
 
 ## Inputs
+
+### Images (container registry)
+- `echo_images` (bool, default: `false`) — provision the Docker remote
+- `echo_image_key_name` / `echo_image_key_value` (string, sensitive) — image access key
+- `echo_image_repository_name` (string, default: `""` → `repository_name`)
+- `echo_registry_url` (string, default: `"https://reg.echohq.com"`)
+- `echo_access_key_secret_name` (string, default: `"echo-gar-mirror-secret"`) — Secret Manager secret name for the image key
+- `echo_access_key_name` / `echo_access_key_value` — **deprecated**, kept for backwards
+  compatibility; when set (and the new image fields are empty) they provision the
+  Docker remote using the image fields.
+
+### Libraries (package registries — one shared library key)
+- `echo_library_pypi` / `echo_library_npm` / `echo_library_maven` (bool, default: `false`)
+- `echo_library_key_name` / `echo_library_key_value` (string, sensitive) — library access key
+- `echo_library_key_secret_name` (string, default: `"echo-gar-mirror-library-secret"`) — Secret Manager secret name for the library key
+- `echo_pypi_url` (default: `"https://pypi.echohq.com"`)
+- `echo_npm_url` (default: `"https://npm.echohq.com"`)
+- `echo_maven_url` (default: `"https://maven.echohq.com"`)
+- `echo_pypi_repository_name` / `echo_npm_repository_name` / `echo_maven_repository_name`
+  (string, default: `""` → `<repository_name>-{pypi,npm,maven}`)
+
+### Shared
 - `create` (bool, default: `true`)
 - `project_id` (string, required)
 - `location` (string, default: `us-central1`)
-- `repository_name` (string, default: `echo`)
+- `repository_name` (string, default: `echo`) — base name; per-format repos derive from it
 - `description` (string, optional)
-- `echo_registry_url` (string, default: `https://reg.echohq.com`)
-- `echo_access_key_name` (string, required)
-- `echo_access_key_value` (string, required, sensitive)
-- `echo_access_key_secret_name` (string, default: `echo-gar-mirror-secret`)
-- `reader_members` (list(string), optional)
-- `writer_members` (list(string), optional)
+- `reader_members` (list(string), optional) — granted reader on every created repo
+- `writer_members` (list(string), optional) — granted writer on every created repo
 - `labels` (map(string), optional)
 
 ## Outputs
-- `repository_id`: The ID of the created Artifact Registry repository
-- `repository_name`: The name of the created Artifact Registry repository
-- `secret_id`: The ID of the created secret containing the Echo access key
-- `secret_version`: The full resource name of the secret version
-- `usage_instructions`: Instructions for using the GAR remote repository
+- `usage_instructions` — per-format pull/install instructions for the created repos
+- `image_repository_key` — Docker remote repository id (or `null`)
+- `library_repository_keys` — list of created library remote repository ids
+- `repository_id` / `repository_name` — Docker remote repository id/name (or `null`)
+- `secret_id` / `secret_version` — image secret id and version name (or `null`)
+- `library_secret_id` — library secret id (or `null`)
 
-## Example usage
+## Example — custom repository names
+
 ```hcl
-module "echo_gar_remote" {
+module "echo_gar_mirror" {
   source = "./echo-terraform-gar-mirror"
-  project_id            = "my-gcp-project"
-  echo_access_key_name  = "my-echo-key-name"
-  echo_access_key_value = "my-echo-key-value"
-}
 
-output "how_to_use" {
-  value = module.echo_gar_remote.usage_instructions
+  project_id      = "my-gcp-project"
+  repository_name = "echo"
+
+  echo_images          = true
+  echo_image_key_name  = var.echo_image_key_name
+  echo_image_key_value = var.echo_image_key_value
+
+  echo_library_pypi         = true
+  echo_pypi_repository_name = "echo-python" # overrides the default "echo-pypi"
+  echo_library_key_name     = var.echo_library_key_name
+  echo_library_key_value    = var.echo_library_key_value
 }
 ```
 
 ## Test
 ```bash
+# Images
 gcloud auth configure-docker <location>-docker.pkg.dev
-docker pull <location>-docker.pkg.dev/<project_id>/<cache_repository_name>/<image>:<tag>
+docker pull <location>-docker.pkg.dev/<project_id>/<repository_name>/<image>:<tag>
+
+# Libraries (examples)
+pip install --index-url https://<location>-python.pkg.dev/<project_id>/<repository_name>-pypi/simple/ <package>
+npm install --registry https://<location>-npm.pkg.dev/<project_id>/<repository_name>-npm/ <package>
 ```

--- a/echo-terraform-gar-mirror/main.tf
+++ b/echo-terraform-gar-mirror/main.tf
@@ -291,3 +291,16 @@ resource "google_artifact_registry_repository_iam_binding" "writers" {
   role       = "roles/artifactregistry.writer"
   members    = var.writer_members
 }
+
+# Preserve state addresses for image-only deployments created before the
+# count -> for_each switch (the single image repo was index [0], now keyed
+# "image"). Without these, existing IAM bindings would be destroyed/recreated.
+moved {
+  from = google_artifact_registry_repository_iam_binding.readers[0]
+  to   = google_artifact_registry_repository_iam_binding.readers["image"]
+}
+
+moved {
+  from = google_artifact_registry_repository_iam_binding.writers[0]
+  to   = google_artifact_registry_repository_iam_binding.writers["image"]
+}

--- a/echo-terraform-gar-mirror/main.tf
+++ b/echo-terraform-gar-mirror/main.tf
@@ -1,5 +1,33 @@
 # Terraform version requirements moved to versions.tf
 
+locals {
+  # Image key: prefer the new echo_image_key_*, fall back to the deprecated
+  # echo_access_key_* so existing image-only deployments keep working.
+  image_key_name  = var.echo_image_key_name != "" ? var.echo_image_key_name : var.echo_access_key_name
+  image_key_value = var.echo_image_key_value != "" ? var.echo_image_key_value : var.echo_access_key_value
+
+  # Provision the Docker remote when explicitly enabled, or (legacy) when a
+  # deprecated access key was supplied.
+  create_docker = var.create && (var.echo_images || nonsensitive(var.echo_access_key_name) != "")
+
+  # Provision the library secret only when at least one library format is on.
+  create_library = var.create && (var.echo_library_pypi || var.echo_library_npm || var.echo_library_maven)
+
+  # Per-format repository ids (overridable, otherwise derived from the base).
+  image_repository = var.echo_image_repository_name != "" ? var.echo_image_repository_name : var.repository_name
+  pypi_repository  = var.echo_pypi_repository_name != "" ? var.echo_pypi_repository_name : "${var.repository_name}-pypi"
+  npm_repository   = var.echo_npm_repository_name != "" ? var.echo_npm_repository_name : "${var.repository_name}-npm"
+  maven_repository = var.echo_maven_repository_name != "" ? var.echo_maven_repository_name : "${var.repository_name}-maven"
+
+  # Repositories created by this module, used to fan out the IAM bindings.
+  created_repositories = merge(
+    local.create_docker ? { image = google_artifact_registry_repository.echo_remote_repo[0] } : {},
+    var.echo_library_pypi ? { pypi = google_artifact_registry_repository.echo_pypi[0] } : {},
+    var.echo_library_npm ? { npm = google_artifact_registry_repository.echo_npm[0] } : {},
+    var.echo_library_maven ? { maven = google_artifact_registry_repository.echo_maven[0] } : {},
+  )
+}
+
 # Enable required APIs
 resource "google_project_service" "secretmanager" {
   count = var.create ? 1 : 0
@@ -21,9 +49,17 @@ resource "google_project_service" "artifactregistry" {
   disable_on_destroy         = false
 }
 
-# Secret Manager for Echo access key
+# Data source to get current project number
+data "google_project" "current" {
+  project_id = var.project_id
+}
+
+# ---------------------------------------------------------------------------
+# Secret Manager — image access key (existing resource addresses unchanged)
+# ---------------------------------------------------------------------------
+
 resource "google_secret_manager_secret" "echo_access_key" {
-  count = var.create ? 1 : 0
+  count = local.create_docker ? 1 : 0
 
   secret_id = var.echo_access_key_secret_name
 
@@ -39,20 +75,50 @@ resource "google_secret_manager_secret" "echo_access_key" {
 }
 
 resource "google_secret_manager_secret_version" "echo_access_key" {
-  count = var.create ? 1 : 0
+  count = local.create_docker ? 1 : 0
 
   secret      = google_secret_manager_secret.echo_access_key[0].id
-  secret_data = var.echo_access_key_value
-
+  secret_data = local.image_key_value
 }
 
-# Artifact Registry Repository for Echo remote integration
+# ---------------------------------------------------------------------------
+# Secret Manager — library access key (shared across library formats)
+# ---------------------------------------------------------------------------
+
+resource "google_secret_manager_secret" "echo_library_key" {
+  count = local.create_library ? 1 : 0
+
+  secret_id = var.echo_library_key_secret_name
+
+  replication {
+    auto {}
+  }
+
+  labels = merge(var.labels, {
+    purpose = "echo-library-authentication"
+  })
+
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_version" "echo_library_key" {
+  count = local.create_library ? 1 : 0
+
+  secret      = google_secret_manager_secret.echo_library_key[0].id
+  secret_data = var.echo_library_key_value
+}
+
+# ---------------------------------------------------------------------------
+# Artifact Registry repositories
+# ---------------------------------------------------------------------------
+
+# Docker remote repository for Echo's image registry
 resource "google_artifact_registry_repository" "echo_remote_repo" {
-  count = var.create ? 1 : 0
+  count = local.create_docker ? 1 : 0
 
   project       = var.project_id
   location      = var.location
-  repository_id = var.repository_name
+  repository_id = local.image_repository
   description   = var.description != "" ? var.description : "Remote repository for Echo Registry integration"
   format        = "DOCKER"
   mode          = "REMOTE_REPOSITORY"
@@ -68,7 +134,7 @@ resource "google_artifact_registry_repository" "echo_remote_repo" {
 
     upstream_credentials {
       username_password_credentials {
-        username                = var.echo_access_key_name
+        username                = local.image_key_name
         password_secret_version = google_secret_manager_secret_version.echo_access_key[0].name
       }
     }
@@ -79,9 +145,111 @@ resource "google_artifact_registry_repository" "echo_remote_repo" {
   depends_on = [google_project_service.artifactregistry]
 }
 
-# IAM binding for Secret Manager access (required for GAR to read the secret)
+# PyPI (PYTHON) remote repository for Echo's PyPI index
+resource "google_artifact_registry_repository" "echo_pypi" {
+  count = var.create && var.echo_library_pypi ? 1 : 0
+
+  project       = var.project_id
+  location      = var.location
+  repository_id = local.pypi_repository
+  description   = var.description != "" ? var.description : "Remote repository for Echo PyPI integration"
+  format        = "PYTHON"
+  mode          = "REMOTE_REPOSITORY"
+
+  remote_repository_config {
+    description = "Remote repository pointing to Echo PyPI (pypi.echohq.com)"
+
+    python_repository {
+      custom_repository {
+        uri = var.echo_pypi_url
+      }
+    }
+
+    upstream_credentials {
+      username_password_credentials {
+        username                = var.echo_library_key_name
+        password_secret_version = google_secret_manager_secret_version.echo_library_key[0].name
+      }
+    }
+  }
+
+  labels = var.labels
+
+  depends_on = [google_project_service.artifactregistry]
+}
+
+# npm (NPM) remote repository for Echo's npm index
+resource "google_artifact_registry_repository" "echo_npm" {
+  count = var.create && var.echo_library_npm ? 1 : 0
+
+  project       = var.project_id
+  location      = var.location
+  repository_id = local.npm_repository
+  description   = var.description != "" ? var.description : "Remote repository for Echo npm integration"
+  format        = "NPM"
+  mode          = "REMOTE_REPOSITORY"
+
+  remote_repository_config {
+    description = "Remote repository pointing to Echo npm (npm.echohq.com)"
+
+    npm_repository {
+      custom_repository {
+        uri = var.echo_npm_url
+      }
+    }
+
+    upstream_credentials {
+      username_password_credentials {
+        username                = var.echo_library_key_name
+        password_secret_version = google_secret_manager_secret_version.echo_library_key[0].name
+      }
+    }
+  }
+
+  labels = var.labels
+
+  depends_on = [google_project_service.artifactregistry]
+}
+
+# Maven (MAVEN) remote repository for Echo's Maven index
+resource "google_artifact_registry_repository" "echo_maven" {
+  count = var.create && var.echo_library_maven ? 1 : 0
+
+  project       = var.project_id
+  location      = var.location
+  repository_id = local.maven_repository
+  description   = var.description != "" ? var.description : "Remote repository for Echo Maven integration"
+  format        = "MAVEN"
+  mode          = "REMOTE_REPOSITORY"
+
+  remote_repository_config {
+    description = "Remote repository pointing to Echo Maven (maven.echohq.com)"
+
+    maven_repository {
+      custom_repository {
+        uri = var.echo_maven_url
+      }
+    }
+
+    upstream_credentials {
+      username_password_credentials {
+        username                = var.echo_library_key_name
+        password_secret_version = google_secret_manager_secret_version.echo_library_key[0].name
+      }
+    }
+  }
+
+  labels = var.labels
+
+  depends_on = [google_project_service.artifactregistry]
+}
+
+# ---------------------------------------------------------------------------
+# IAM — secret accessor for the GAR service account (per created secret)
+# ---------------------------------------------------------------------------
+
 resource "google_secret_manager_secret_iam_member" "gar_secret_accessor" {
-  count = var.create ? 1 : 0
+  count = local.create_docker ? 1 : 0
 
   secret_id = google_secret_manager_secret.echo_access_key[0].id
   role      = "roles/secretmanager.secretAccessor"
@@ -90,28 +258,36 @@ resource "google_secret_manager_secret_iam_member" "gar_secret_accessor" {
   depends_on = [google_project_service.artifactregistry]
 }
 
-# Data source to get current project number
-data "google_project" "current" {
-  project_id = var.project_id
+resource "google_secret_manager_secret_iam_member" "gar_library_secret_accessor" {
+  count = local.create_library ? 1 : 0
+
+  secret_id = google_secret_manager_secret.echo_library_key[0].id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:service-${data.google_project.current.number}@gcp-sa-artifactregistry.iam.gserviceaccount.com"
+
+  depends_on = [google_project_service.artifactregistry]
 }
 
-# IAM bindings for Artifact Registry repository access
+# ---------------------------------------------------------------------------
+# IAM — repository reader/writer bindings (applied per created repository)
+# ---------------------------------------------------------------------------
+
 resource "google_artifact_registry_repository_iam_binding" "readers" {
-  count = var.create && length(var.reader_members) > 0 ? 1 : 0
+  for_each = length(var.reader_members) > 0 ? local.created_repositories : {}
 
   project    = var.project_id
-  location   = google_artifact_registry_repository.echo_remote_repo[0].location
-  repository = google_artifact_registry_repository.echo_remote_repo[0].name
+  location   = each.value.location
+  repository = each.value.name
   role       = "roles/artifactregistry.reader"
   members    = var.reader_members
 }
 
 resource "google_artifact_registry_repository_iam_binding" "writers" {
-  count = var.create && length(var.writer_members) > 0 ? 1 : 0
+  for_each = length(var.writer_members) > 0 ? local.created_repositories : {}
 
   project    = var.project_id
-  location   = google_artifact_registry_repository.echo_remote_repo[0].location
-  repository = google_artifact_registry_repository.echo_remote_repo[0].name
+  location   = each.value.location
+  repository = each.value.name
   role       = "roles/artifactregistry.writer"
   members    = var.writer_members
 }

--- a/echo-terraform-gar-mirror/outputs.tf
+++ b/echo-terraform-gar-mirror/outputs.tf
@@ -1,25 +1,48 @@
 output "repository_id" {
-  description = "The ID of the created Artifact Registry repository"
-  value       = var.create ? google_artifact_registry_repository.echo_remote_repo[0].repository_id : null
+  description = "The ID of the created Docker (image) Artifact Registry repository, if created."
+  value       = local.create_docker ? google_artifact_registry_repository.echo_remote_repo[0].repository_id : null
 }
 
 output "repository_name" {
-  description = "The name of the created Artifact Registry repository"
-  value       = var.create ? google_artifact_registry_repository.echo_remote_repo[0].name : null
+  description = "The name of the created Docker (image) Artifact Registry repository, if created."
+  value       = local.create_docker ? google_artifact_registry_repository.echo_remote_repo[0].name : null
 }
 
+output "image_repository_key" {
+  description = "Repository id of the Docker (image) remote, if created."
+  value       = local.create_docker ? local.image_repository : null
+}
+
+output "library_repository_keys" {
+  description = "Repository ids of the library remotes that were created."
+  value = compact([
+    var.echo_library_pypi ? local.pypi_repository : "",
+    var.echo_library_npm ? local.npm_repository : "",
+    var.echo_library_maven ? local.maven_repository : "",
+  ])
+}
 
 output "secret_id" {
-  description = "The ID of the created secret containing the Echo access key"
-  value       = var.create ? google_secret_manager_secret.echo_access_key[0].secret_id : null
+  description = "The ID of the secret containing the Echo image access key, if created."
+  value       = local.create_docker ? google_secret_manager_secret.echo_access_key[0].secret_id : null
 }
-
 
 output "secret_version" {
-  description = "The full resource name of the secret version"
-  value       = var.create ? google_secret_manager_secret_version.echo_access_key[0].name : null
+  description = "The full resource name of the image secret version, if created."
+  value       = local.create_docker ? google_secret_manager_secret_version.echo_access_key[0].name : null
 }
+
+output "library_secret_id" {
+  description = "The ID of the secret containing the Echo library access key, if created."
+  value       = local.create_library ? google_secret_manager_secret.echo_library_key[0].secret_id : null
+}
+
 output "usage_instructions" {
-  description = "Instructions for using the GAR remote repository"
-  value       = var.create ? "docker pull ${var.location}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.echo_remote_repo[0].repository_id}/static:latest" : null
+  description = "Instructions for using the Echo remote repositories provisioned in GAR."
+  value = var.create ? join("\n", compact([
+    local.create_docker ? "Images:  docker pull ${var.location}-docker.pkg.dev/${var.project_id}/${local.image_repository}/static:latest" : "",
+    var.echo_library_pypi ? "PyPI:    pip install --index-url https://${var.location}-python.pkg.dev/${var.project_id}/${local.pypi_repository}/simple/ <package>" : "",
+    var.echo_library_npm ? "npm:     npm install --registry https://${var.location}-npm.pkg.dev/${var.project_id}/${local.npm_repository}/ <package>" : "",
+    var.echo_library_maven ? "Maven:   add https://${var.location}-maven.pkg.dev/${var.project_id}/${local.maven_repository} as a repository in your settings.xml" : "",
+  ])) : null
 }

--- a/echo-terraform-gar-mirror/variables.tf
+++ b/echo-terraform-gar-mirror/variables.tf
@@ -25,7 +25,7 @@ variable "location" {
 }
 
 variable "repository_name" {
-  description = "Repository name for cached images - This will be the name of your repository"
+  description = "Base repository name. Per-format repositories derive from it (e.g. <name>, <name>-pypi, <name>-npm, <name>-maven) unless overridden."
   type        = string
   default     = "echo"
 
@@ -36,13 +36,43 @@ variable "repository_name" {
 }
 
 variable "description" {
-  description = "Description for the Artifact Registry repository"
+  description = "Description for the Artifact Registry repositories"
   type        = string
   default     = "Remote repository for Echo Registry integration"
 }
 
+# ---------------------------------------------------------------------------
+# Images (container registry)
+# ---------------------------------------------------------------------------
+
+variable "echo_images" {
+  description = "Provision the Docker remote repository that proxies Echo's image registry."
+  type        = bool
+  default     = false
+}
+
+variable "echo_image_key_name" {
+  description = "Echo image access key name (username) for the Docker remote."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "echo_image_key_value" {
+  description = "Echo image access key value (password) for the Docker remote."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "echo_image_repository_name" {
+  description = "Optional override for the Docker remote repository id. Defaults to repository_name."
+  type        = string
+  default     = ""
+}
+
 variable "echo_registry_url" {
-  description = "URL of the Echo registry"
+  description = "URL of the Echo image registry."
   type        = string
   default     = "https://reg.echohq.com"
 
@@ -52,31 +82,134 @@ variable "echo_registry_url" {
   }
 }
 
+# Deprecated: kept for backwards compatibility with the original image-only
+# module. When set (and the new echo_image_key_* are empty) it provisions the
+# Docker remote. Prefer echo_images + echo_image_key_name/value.
 variable "echo_access_key_name" {
-  description = "The name of the Echo access key (used as username for authentication)"
+  description = "Deprecated. Use echo_image_key_name. Echo access key name (used as username for authentication)."
   type        = string
+  default     = ""
+  sensitive   = true
 }
 
 variable "echo_access_key_value" {
-  description = "The value of the Echo access key (used as password for authentication)"
+  description = "Deprecated. Use echo_image_key_value. Echo access key value (used as password for authentication)."
   type        = string
+  default     = ""
   sensitive   = true
 }
 
 variable "echo_access_key_secret_name" {
-  description = "Custom secret name for the Echo access key. If not provided"
+  description = "Secret Manager secret name for the Echo image access key."
   type        = string
   default     = "echo-gar-mirror-secret"
 }
 
+# ---------------------------------------------------------------------------
+# Libraries (package registries) — one shared library key across ecosystems
+# ---------------------------------------------------------------------------
+
+variable "echo_library_pypi" {
+  description = "Provision the PyPI (PYTHON) remote repository that proxies Echo's PyPI index."
+  type        = bool
+  default     = false
+}
+
+variable "echo_library_npm" {
+  description = "Provision the npm (NPM) remote repository that proxies Echo's npm index."
+  type        = bool
+  default     = false
+}
+
+variable "echo_library_maven" {
+  description = "Provision the Maven (MAVEN) remote repository that proxies Echo's Maven index."
+  type        = bool
+  default     = false
+}
+
+variable "echo_library_key_name" {
+  description = "Echo library access key name (username) for the library remotes."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "echo_library_key_value" {
+  description = "Echo library access key value (password) for the library remotes."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "echo_library_key_secret_name" {
+  description = "Secret Manager secret name for the Echo library access key."
+  type        = string
+  default     = "echo-gar-mirror-library-secret"
+}
+
+variable "echo_pypi_url" {
+  description = "URL of the Echo PyPI index."
+  type        = string
+  default     = "https://pypi.echohq.com"
+
+  validation {
+    condition     = can(regex("^https://", var.echo_pypi_url))
+    error_message = "Echo PyPI URL must be a valid HTTPS URL."
+  }
+}
+
+variable "echo_npm_url" {
+  description = "URL of the Echo npm index."
+  type        = string
+  default     = "https://npm.echohq.com"
+
+  validation {
+    condition     = can(regex("^https://", var.echo_npm_url))
+    error_message = "Echo npm URL must be a valid HTTPS URL."
+  }
+}
+
+variable "echo_maven_url" {
+  description = "URL of the Echo Maven index."
+  type        = string
+  default     = "https://maven.echohq.com"
+
+  validation {
+    condition     = can(regex("^https://", var.echo_maven_url))
+    error_message = "Echo Maven URL must be a valid HTTPS URL."
+  }
+}
+
+variable "echo_pypi_repository_name" {
+  description = "Optional override for the PyPI remote repository id. Defaults to <repository_name>-pypi."
+  type        = string
+  default     = ""
+}
+
+variable "echo_npm_repository_name" {
+  description = "Optional override for the npm remote repository id. Defaults to <repository_name>-npm."
+  type        = string
+  default     = ""
+}
+
+variable "echo_maven_repository_name" {
+  description = "Optional override for the Maven remote repository id. Defaults to <repository_name>-maven."
+  type        = string
+  default     = ""
+}
+
+# ---------------------------------------------------------------------------
+# IAM
+# ---------------------------------------------------------------------------
+
 variable "reader_members" {
-  description = "List of members to grant read access to the repository"
+  description = "List of members to grant read access to the created repositories"
   type        = list(string)
   default     = []
 }
 
 variable "writer_members" {
-  description = "List of members to grant write access to the repository"
+  description = "List of members to grant write access to the created repositories"
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
## Summary

Extends the GAR (Google Artifact Registry) Terraform and Pulumi modules to mirror Echo **libraries** (PyPI/npm/Maven) in addition to **images**, matching the JFrog/Nexus work. Each artifact format is provisioned as a separate `google_artifact_registry_repository` with `mode = "REMOTE_REPOSITORY"`, gated behind its own flag.

## Images + Libraries

- **Images** (`DOCKER`): `echo_images` + `echo_image_key_name`/`echo_image_key_value`, endpoint `echo_registry_url` (default `https://reg.echohq.com`).
- **Libraries** (`PYTHON`/`NPM`/`MAVEN`): `echo_library_pypi`/`echo_library_npm`/`echo_library_maven`, one shared `echo_library_key_name`/`echo_library_key_value`, endpoints `echo_pypi_url`/`echo_npm_url`/`echo_maven_url`.
- Base `repository_name` (default `echo`); per-format repo ids derive as `<base>-pypi`/`-npm`/`-maven` (image uses the base), each overridable via `echo_{image,pypi,npm,maven}_repository_name`.

## Secret-Manager auth

The image key and library key are **distinct** Secret Manager secrets (`echo_access_key_secret_name` and new `echo_library_key_secret_name`). Each per-format repo's `upstream_credentials.username_password_credentials` references the matching secret version + username. The GAR service account gets `secretAccessor` on each created secret.

## Backward compatibility

- Deprecated `echo_access_key_name`/`echo_access_key_value` are now optional (default `""`, marked DEPRECATED) and still provision the Docker remote when set; the new image fields take precedence when both are present.
- The Docker repo keeps its existing resource address (`google_artifact_registry_repository.echo_remote_repo`) and the image secret resources keep their existing addresses, so existing state does not churn.
- Docker creation is gated on `var.create && (var.echo_images || nonsensitive(var.echo_access_key_name) != "")`.

## Outputs

`usage_instructions` (multi-line, per-format pull/install lines for created repos only, using GAR URL scheme: `<location>-docker.pkg.dev`, `<location>-python.pkg.dev/.../simple/`, `<location>-npm.pkg.dev`, `<location>-maven.pkg.dev`), `image_repository_key`, `library_repository_keys`, plus existing `repository_id`/`repository_name`/`secret_id`/`secret_version` and new `library_secret_id`.

## Pulumi

Mirrors the same flags/fields in camelCase on `GcpGarRemoteInput`; creates the library secret + per-format `gcp.artifactregistry.Repository` conditionally. Keeps the existing docker repo resource name (`${name}-remote-repo`) and image secret resource names unchanged. Deprecated `echoAccessKeyName/Value` still work.

## Verification

- Terraform: `terraform fmt && terraform validate` → **Success! The configuration is valid.**
- Pulumi: `npx tsc --noEmit` → **clean (exit 0)**.

## Deviations

- IAM reader/writer bindings now fan out per created repository (TF `for_each` over created repos; Pulumi indexed resources `${name}-readers-<i>`). The repo/secret resource addresses are preserved as required, but the IAM binding addresses change. For existing deployments that set reader/writer members, the bindings will be recreated idempotently (same role/members) — no access change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Secret Manager credentials, Artifact Registry remotes, and IAM across multiple repos; Terraform IAM binding address changes are mitigated with `moved` blocks but upgrades still need a careful plan.
> 
> **Overview**
> Extends the **Echo GAR mirror** Terraform and Pulumi modules so one stack can optionally proxy Echo **images** (Docker) and **libraries** (PyPI, npm, Maven), each behind its own enable flag instead of always provisioning a single Docker remote.
> 
> **Credentials and repos:** Image auth uses `echo_image_key_*` (or deprecated `echo_access_key_*`) in the existing image Secret Manager secret; library formats share a **separate** library secret and `echo_library_key_*`. Each enabled format gets its own `REMOTE_REPOSITORY` with upstream URLs and derived or overridden repo ids (`<base>-pypi`, etc.).
> 
> **IAM and outputs:** Reader/writer bindings apply to **every** created repo (Terraform `for_each` with `moved` blocks for the image-only binding address; Pulumi keeps the first binding name unchanged and suffixes extras). Outputs add `image_repository_key`, `library_repository_keys`, `library_secret_id`, and multi-line `usage_instructions`; legacy Docker/secret outputs remain but are optional when Docker is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9045f5167722c347d6773bfadcc9556ca2914cdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->