### PR TITLE
[ECH-5267] feat(cloudsmith): net-new Terraform mirror module (images + PyPI/npm/maven)

### DIFF
--- a/echo-terraform-cloudsmith-mirror/README.md
+++ b/echo-terraform-cloudsmith-mirror/README.md
@@ -1,0 +1,108 @@
+# Echo Cloudsmith Mirror - Terraform Module
+
+Configures Cloudsmith as a proxy/cache for Echo. One module provisions a Docker
+repository for **images** and/or PyPI / npm / Maven repositories for
+**libraries**, based on the inputs. Each repository (and its upstream) is created
+only when its flag is set.
+
+> Terraform + Manual onboarding only. Cloudsmith has no first-class Pulumi
+> provider, so there is intentionally no Pulumi module for Cloudsmith.
+
+## Quickstart
+
+```hcl
+provider "cloudsmith" {
+  api_key = var.cloudsmith_api_key
+}
+
+module "echo_cloudsmith_mirror" {
+  source = "git@github.com:buildecho/onboarding-providers.git//echo-terraform-cloudsmith-mirror"
+
+  namespace = "your-cloudsmith-org-slug"
+
+  # Images
+  echo_images          = true
+  echo_image_key_name  = var.echo_image_key_name
+  echo_image_key_value = var.echo_image_key_value
+
+  # Libraries (one shared library key)
+  echo_library_pypi      = true
+  echo_library_npm       = true
+  echo_library_key_name  = var.echo_library_key_name
+  echo_library_key_value = var.echo_library_key_value
+}
+
+output "usage_instructions" {
+  value = module.echo_cloudsmith_mirror.usage_instructions
+}
+```
+
+```bash
+terraform init && terraform apply
+```
+
+## Inputs
+
+### Images (container registry)
+- `echo_images` (bool, default: `false`) — provision the Docker repository + upstream
+- `echo_image_key_name` / `echo_image_key_value` (string, sensitive) — image access key (upstream auth)
+- `echo_image_repository_name` (string, default: `""` → `repository_name`)
+- `echo_registry_url` (string, default: `"https://reg.echohq.com"`)
+
+### Libraries (package registries — one shared library key)
+- `echo_library_pypi` / `echo_library_npm` / `echo_library_maven` (bool, default: `false`)
+- `echo_library_key_name` / `echo_library_key_value` (string, sensitive) — library access key (upstream auth)
+- `echo_pypi_url` (default: `"https://pypi.echohq.com"`)
+- `echo_npm_url` (default: `"https://npm.echohq.com"`)
+- `echo_maven_url` (default: `"https://maven.echohq.com"`)
+- `echo_pypi_repository_name` / `echo_npm_repository_name` / `echo_maven_repository_name`
+  (string, default: `""` → `<repository_name>-{pypi,npm,maven}`)
+
+### Shared
+- `create` (bool, default: `true`) — master gate for all resources
+- `namespace` (string, required) — Cloudsmith organization slug that owns the repositories
+- `repository_name` (string, default: `"echo"`) — base slug; per-format repos derive from it
+- `description` (string, default: `"Echo mirror repository (managed by Terraform)"`)
+- `repository_type` (string, default: `"Private"`) — one of `Public`, `Private`, `Open-Source`
+- `upstream_mode` (string, default: `"Cache and Proxy"`) — one of `Proxy Only`, `Cache and Proxy`
+
+## Outputs
+- `usage_instructions` — per-format pull/install instructions for created repos
+- `image_repository_name` — Docker repository slug (or `null`)
+- `library_repository_names` — list of created library repository slugs
+
+## Example — custom repository names
+
+```hcl
+module "echo_cloudsmith_mirror" {
+  source = "./echo-terraform-cloudsmith-mirror"
+
+  namespace       = "your-cloudsmith-org-slug"
+  repository_name = "echo"
+
+  echo_images          = true
+  echo_image_key_name  = var.echo_image_key_name
+  echo_image_key_value = var.echo_image_key_value
+
+  echo_library_pypi         = true
+  echo_pypi_repository_name = "echo-python" # overrides the default "echo-pypi"
+  echo_library_key_name     = var.echo_library_key_name
+  echo_library_key_value    = var.echo_library_key_value
+}
+```
+
+## Provider Configuration
+
+The Cloudsmith provider needs an API key (a Cloudsmith user/service API key with
+permission to manage repositories in the namespace). Get it from the Cloudsmith
+dashboard under your account API settings.
+
+```hcl
+provider "cloudsmith" {
+  api_key = var.cloudsmith_api_key # or set CLOUDSMITH_API_KEY
+}
+```
+
+The Echo access keys supplied to `echo_*_key_name` / `echo_*_key_value` are used
+as the upstream (`Username and Password`) authentication so Cloudsmith can reach
+the Echo endpoints.

--- a/echo-terraform-cloudsmith-mirror/main.tf
+++ b/echo-terraform-cloudsmith-mirror/main.tf
@@ -1,0 +1,119 @@
+# Terraform version requirements live in versions.tf
+
+locals {
+  # Gate each format on the module-level create flag plus its own toggle.
+  create_docker = var.create && var.echo_images
+  create_pypi   = var.create && var.echo_library_pypi
+  create_npm    = var.create && var.echo_library_npm
+  create_maven  = var.create && var.echo_library_maven
+
+  # Per-format repository slugs (overridable, otherwise derived from the base).
+  image_repository = var.echo_image_repository_name != "" ? var.echo_image_repository_name : var.repository_name
+  pypi_repository  = var.echo_pypi_repository_name != "" ? var.echo_pypi_repository_name : "${var.repository_name}-pypi"
+  npm_repository   = var.echo_npm_repository_name != "" ? var.echo_npm_repository_name : "${var.repository_name}-npm"
+  maven_repository = var.echo_maven_repository_name != "" ? var.echo_maven_repository_name : "${var.repository_name}-maven"
+}
+
+# ---------------------------------------------------------------------------
+# Images (Docker)
+# ---------------------------------------------------------------------------
+
+resource "cloudsmith_repository" "echo_image" {
+  count = local.create_docker ? 1 : 0
+
+  name            = local.image_repository
+  slug            = local.image_repository
+  namespace       = var.namespace
+  description     = var.description
+  repository_type = var.repository_type
+}
+
+resource "cloudsmith_repository_upstream" "echo_image" {
+  count = local.create_docker ? 1 : 0
+
+  name          = "Echo Images"
+  namespace     = var.namespace
+  repository    = cloudsmith_repository.echo_image[0].slug_perm
+  upstream_type = "docker"
+  upstream_url  = var.echo_registry_url
+  mode          = var.upstream_mode
+  auth_mode     = "Username and Password"
+  auth_username = var.echo_image_key_name
+  auth_secret   = var.echo_image_key_value
+}
+
+# ---------------------------------------------------------------------------
+# Libraries (PyPI / npm / Maven) — one shared library key
+# ---------------------------------------------------------------------------
+
+resource "cloudsmith_repository" "echo_pypi" {
+  count = local.create_pypi ? 1 : 0
+
+  name            = local.pypi_repository
+  slug            = local.pypi_repository
+  namespace       = var.namespace
+  description     = var.description
+  repository_type = var.repository_type
+}
+
+resource "cloudsmith_repository_upstream" "echo_pypi" {
+  count = local.create_pypi ? 1 : 0
+
+  name          = "Echo PyPI"
+  namespace     = var.namespace
+  repository    = cloudsmith_repository.echo_pypi[0].slug_perm
+  upstream_type = "python"
+  upstream_url  = var.echo_pypi_url
+  mode          = var.upstream_mode
+  auth_mode     = "Username and Password"
+  auth_username = var.echo_library_key_name
+  auth_secret   = var.echo_library_key_value
+}
+
+resource "cloudsmith_repository" "echo_npm" {
+  count = local.create_npm ? 1 : 0
+
+  name            = local.npm_repository
+  slug            = local.npm_repository
+  namespace       = var.namespace
+  description     = var.description
+  repository_type = var.repository_type
+}
+
+resource "cloudsmith_repository_upstream" "echo_npm" {
+  count = local.create_npm ? 1 : 0
+
+  name          = "Echo npm"
+  namespace     = var.namespace
+  repository    = cloudsmith_repository.echo_npm[0].slug_perm
+  upstream_type = "npm"
+  upstream_url  = var.echo_npm_url
+  mode          = var.upstream_mode
+  auth_mode     = "Username and Password"
+  auth_username = var.echo_library_key_name
+  auth_secret   = var.echo_library_key_value
+}
+
+resource "cloudsmith_repository" "echo_maven" {
+  count = local.create_maven ? 1 : 0
+
+  name            = local.maven_repository
+  slug            = local.maven_repository
+  namespace       = var.namespace
+  description     = var.description
+  repository_type = var.repository_type
+}
+
+resource "cloudsmith_repository_upstream" "echo_maven" {
+  count = local.create_maven ? 1 : 0
+
+  name          = "Echo Maven"
+  namespace     = var.namespace
+  repository    = cloudsmith_repository.echo_maven[0].slug_perm
+  upstream_type = "maven"
+  upstream_url  = var.echo_maven_url
+  mode          = var.upstream_mode
+  auth_mode     = "Username and Password"
+  auth_username = var.echo_library_key_name
+  auth_secret   = var.echo_library_key_value
+}

--- a/echo-terraform-cloudsmith-mirror/outputs.tf
+++ b/echo-terraform-cloudsmith-mirror/outputs.tf
@@ -1,0 +1,23 @@
+output "usage_instructions" {
+  description = "Instructions for consuming the Echo repositories provisioned in Cloudsmith."
+  value = var.create ? join("\n", compact([
+    local.create_docker ? "Images:  docker pull docker.cloudsmith.io/${var.namespace}/${local.image_repository}/<image>:<tag>" : "",
+    local.create_pypi ? "PyPI:    pip install --index-url https://dl.cloudsmith.io/<token>/${var.namespace}/${local.pypi_repository}/python/simple/ <package>" : "",
+    local.create_npm ? "npm:     npm install --registry https://npm.cloudsmith.io/${var.namespace}/${local.npm_repository}/ <package>" : "",
+    local.create_maven ? "Maven:   add https://dl.cloudsmith.io/<token>/${var.namespace}/${local.maven_repository}/maven/ as a repository in your pom.xml / settings.xml" : "",
+  ])) : null
+}
+
+output "image_repository_name" {
+  description = "Slug of the Docker repository, if created."
+  value       = local.create_docker ? local.image_repository : null
+}
+
+output "library_repository_names" {
+  description = "Slugs of the library repositories that were created."
+  value = compact([
+    local.create_pypi ? local.pypi_repository : "",
+    local.create_npm ? local.npm_repository : "",
+    local.create_maven ? local.maven_repository : "",
+  ])
+}

--- a/echo-terraform-cloudsmith-mirror/variables.tf
+++ b/echo-terraform-cloudsmith-mirror/variables.tf
@@ -1,0 +1,156 @@
+variable "create" {
+  type        = bool
+  description = "Whether to provision the resources under this module"
+  default     = true
+}
+
+variable "namespace" {
+  type        = string
+  description = "Cloudsmith namespace (organization slug) that owns the repositories."
+}
+
+variable "repository_name" {
+  type        = string
+  description = "Base name for the Cloudsmith repositories. Per-format repositories derive from it (e.g. <name>, <name>-pypi, <name>-npm, <name>-maven) unless overridden."
+  default     = "echo"
+}
+
+# ---------------------------------------------------------------------------
+# Images (container registry)
+# ---------------------------------------------------------------------------
+
+variable "echo_images" {
+  type        = bool
+  description = "Provision the Docker repository + upstream that proxies Echo's image registry."
+  default     = false
+}
+
+variable "echo_image_key_name" {
+  type        = string
+  description = "Echo image access key name (username) for the Docker upstream auth."
+  default     = ""
+  sensitive   = true
+}
+
+variable "echo_image_key_value" {
+  type        = string
+  description = "Echo image access key value (secret) for the Docker upstream auth."
+  default     = ""
+  sensitive   = true
+}
+
+variable "echo_image_repository_name" {
+  type        = string
+  description = "Optional override for the Docker repository slug. Defaults to repository_name."
+  default     = ""
+}
+
+variable "echo_registry_url" {
+  type        = string
+  description = "URL of the Echo image registry."
+  default     = "https://reg.echohq.com"
+}
+
+# ---------------------------------------------------------------------------
+# Libraries (package registries) — one shared library key across ecosystems
+# ---------------------------------------------------------------------------
+
+variable "echo_library_pypi" {
+  type        = bool
+  description = "Provision the PyPI repository + upstream that proxies Echo's PyPI index."
+  default     = false
+}
+
+variable "echo_library_npm" {
+  type        = bool
+  description = "Provision the npm repository + upstream that proxies Echo's npm index."
+  default     = false
+}
+
+variable "echo_library_maven" {
+  type        = bool
+  description = "Provision the Maven repository + upstream that proxies Echo's Maven index."
+  default     = false
+}
+
+variable "echo_library_key_name" {
+  type        = string
+  description = "Echo library access key name (username) for the library upstream auth."
+  default     = ""
+  sensitive   = true
+}
+
+variable "echo_library_key_value" {
+  type        = string
+  description = "Echo library access key value (secret) for the library upstream auth."
+  default     = ""
+  sensitive   = true
+}
+
+variable "echo_pypi_url" {
+  type        = string
+  description = "URL of the Echo PyPI index."
+  default     = "https://pypi.echohq.com"
+}
+
+variable "echo_npm_url" {
+  type        = string
+  description = "URL of the Echo npm index."
+  default     = "https://npm.echohq.com"
+}
+
+variable "echo_maven_url" {
+  type        = string
+  description = "URL of the Echo Maven index."
+  default     = "https://maven.echohq.com"
+}
+
+variable "echo_pypi_repository_name" {
+  type        = string
+  description = "Optional override for the PyPI repository slug. Defaults to <repository_name>-pypi."
+  default     = ""
+}
+
+variable "echo_npm_repository_name" {
+  type        = string
+  description = "Optional override for the npm repository slug. Defaults to <repository_name>-npm."
+  default     = ""
+}
+
+variable "echo_maven_repository_name" {
+  type        = string
+  description = "Optional override for the Maven repository slug. Defaults to <repository_name>-maven."
+  default     = ""
+}
+
+# ---------------------------------------------------------------------------
+# Shared repository configuration
+# ---------------------------------------------------------------------------
+
+variable "description" {
+  type        = string
+  description = "Description applied to the Cloudsmith repositories."
+  default     = "Echo mirror repository (managed by Terraform)"
+}
+
+variable "repository_type" {
+  type        = string
+  description = "Cloudsmith repository visibility type."
+  default     = "Private"
+
+  validation {
+    condition     = contains(["Public", "Private", "Open-Source"], var.repository_type)
+    error_message = "repository_type must be one of: Public, Private, Open-Source."
+  }
+}
+
+variable "upstream_mode" {
+  type        = string
+  description = "Operating mode for the upstreams."
+  default     = "Cache and Proxy"
+
+  validation {
+    condition     = contains(["Proxy Only", "Cache and Proxy"], var.upstream_mode)
+    error_message = "upstream_mode must be one of: Proxy Only, Cache and Proxy."
+  }
+}

--- a/echo-terraform-cloudsmith-mirror/versions.tf
+++ b/echo-terraform-cloudsmith-mirror/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    cloudsmith = {
+      source  = "cloudsmith-io/cloudsmith"
+      version = ">= 0.0.49"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Net-new Terraform IaC module for **Cloudsmith** (`echo-terraform-cloudsmith-mirror/`), mirroring Echo **images** (Docker) and **libraries** (PyPI/npm/maven). Follows the pattern established for JFrog/Nexus/GAR. Nothing existed for Cloudsmith before.

- Each selected format provisions a `cloudsmith_repository` + a `cloudsmith_repository_upstream` (`upstream_type` = `docker`/`python`/`npm`/`maven`) proxying the matching Echo endpoint.
- Docker uses the image key; PyPI/npm/Maven share the library key. Both wired as `auth_mode = "Username and Password"` upstream auth (`auth_username`/`auth_secret`).
- Per-format repo slugs derive from `repository_name` (`echo`, `echo-pypi`, `echo-npm`, `echo-maven`) with optional overrides; `create` master gate + per-format toggles default off.
- `namespace` (Cloudsmith org slug) variable; provider needs `api_key` (documented in README).
- Outputs: `usage_instructions` (per-format Cloudsmith consumption URLs), `image_repository_name`, `library_repository_names`.

## Pulumi rationale

This PR is the **Terraform half only**. Pulumi is intentionally **out of scope** — Cloudsmith has no first-class Pulumi provider, so the UI will offer Terraform + Manual only.

## Verification

`terraform fmt` + `terraform init -backend=false` + `terraform validate` → **Success!** against provider `cloudsmith-io/cloudsmith` v0.0.75 (constraint `>= 0.0.49`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New IaC that stores Echo access keys as sensitive upstream secrets and creates external registry resources; misconfiguration could break pulls or expose credentials in state if mishandled.
> 
> **Overview**
> Adds a **net-new** Terraform module at `echo-terraform-cloudsmith-mirror/` so customers can mirror Echo **Docker images** and **PyPI / npm / Maven** libraries through Cloudsmith proxy/cache repos—filling a gap where no Cloudsmith onboarding IaC existed before (Terraform + manual only; no Pulumi).
> 
> For each enabled format, the module creates a `cloudsmith_repository` plus a matching `cloudsmith_repository_upstream` to the Echo endpoints (`reg`, `pypi`, `npm`, `maven`), with **username/password** upstream auth: image key for Docker, one shared library key for package formats. Creation is gated by `create` and per-format toggles (defaults off); repo slugs come from `repository_name` with optional per-format overrides. Variables cover namespace, visibility, and upstream mode; outputs expose consumption hints (`usage_instructions`) and created repo slugs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7418ed907ed88d0eb4d270c8157cd4a65a74eee9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->