### PR TITLE
feat(jfrog): pypi /simple + token-only auth; disable non-jfrog library IaC

### DIFF
--- a/echo-pulumi-gar-mirror/README.md
+++ b/echo-pulumi-gar-mirror/README.md
@@ -45,6 +45,8 @@ export const usage = remote.usageInstructions;
   compatibility; provisions the Docker remote when set.
 
 ### Libraries (package registries — one shared library key)
+> **Disabled for now.** The library remotes are commented out in `index.ts`; these inputs are accepted but provision nothing until libraries are turned on.
+
 - `echoLibraryPypi` / `echoLibraryNpm` / `echoLibraryMaven` (boolean, default: `false`)
 - `echoLibraryKeyName` / `echoLibraryKeyValue` (Input<string>, secret) — library access key
 - `echoLibraryKeySecretName` (string, default: `echo-gar-mirror-library-secret`) — Secret Manager secret name for the library key

--- a/echo-pulumi-gar-mirror/index.ts
+++ b/echo-pulumi-gar-mirror/index.ts
@@ -212,7 +212,8 @@ export class GcpGarRemote extends pulumi.ComponentResource {
         const repositoryName = args.repositoryName || "echo";
         const description = args.description || "Remote repository for Echo Registry integration";
         const imageSecretName = args.echoAccessKeySecretName || "echo-gar-mirror-secret";
-        const librarySecretName = args.echoLibraryKeySecretName || "echo-gar-mirror-library-secret";
+        // Libraries disabled for now.
+        // const librarySecretName = args.echoLibraryKeySecretName || "echo-gar-mirror-library-secret";
 
         const labels = { ...args.labels };
 
@@ -297,8 +298,13 @@ export class GcpGarRemote extends pulumi.ComponentResource {
         }
 
         // --- Library remotes (one shared library key) ---
-        const createLibrary = args.echoLibraryPypi === true || args.echoLibraryNpm === true || args.echoLibraryMaven === true;
+        // DISABLED for now. The library remotes below are commented out;
+        // re-enable them when libraries are turned on. The empty
+        // `libraryRepositoryKeys` keeps the output contract intact ([] for now).
         const libraryRepositoryKeys: pulumi.Output<string>[] = [];
+
+        /*
+        const createLibrary = args.echoLibraryPypi === true || args.echoLibraryNpm === true || args.echoLibraryMaven === true;
 
         if (createLibrary) {
             const librarySecret = new gcp.secretmanager.Secret(`${name}-echo-library-key`, {
@@ -408,6 +414,7 @@ export class GcpGarRemote extends pulumi.ComponentResource {
                 instructions.push(`Maven:   add https://${location}-maven.pkg.dev/${args.projectId}/${key} as a repository in your settings.xml`);
             }
         }
+        */
 
         // Create IAM bindings for repository readers/writers across all created
         // repos. The first repo (the image remote, index 0) keeps the unindexed

--- a/echo-pulumi-jfrog-mirror/README.md
+++ b/echo-pulumi-jfrog-mirror/README.md
@@ -41,8 +41,13 @@ export const usageInstructions = integration.usageInstructions;
 
 ### Libraries (one shared library key)
 - `echoLibraryPypi` / `echoLibraryNpm` / `echoLibraryMaven` (boolean, default `false`)
-- `echoLibraryKeyName` / `echoLibraryKeyValue` — library access key
-- `echoPypiUrl` / `echoNpmUrl` / `echoMavenUrl` (defaults `https://{pypi,npm,maven}.echohq.com`)
+- `echoLibraryKeyValue` — library access key. Authentication is **token-only**: this
+  value is the password.
+- `echoLibraryKeyName` — **no-op**. Accepted for parity with the image flow, but Echo's
+  library index ignores the username.
+- `echoPypiUrl` (default `https://pypi.echohq.com/simple` — only PyPI carries the
+  `/simple` suffix) / `echoNpmUrl` (default `https://npm.echohq.com`) / `echoMavenUrl`
+  (default `https://maven.echohq.com`)
 - `echoPypiRepositoryName` / `echoNpmRepositoryName` / `echoMavenRepositoryName`
   (default → `<remoteRepositoryName>-{pypi,npm,maven}`)
 

--- a/echo-pulumi-jfrog-mirror/index.ts
+++ b/echo-pulumi-jfrog-mirror/index.ts
@@ -56,13 +56,21 @@ export interface JfrogIntegrationInput {
     /** Provision the Maven remote that proxies Echo's Maven index. */
     echoLibraryMaven?: boolean;
 
-    /** Echo library access key name (username) for the library remotes. */
+    /**
+     * Echo library access key name (username) for the library remotes. No-op:
+     * Echo's library index authenticates by token only (the key value is the
+     * password), so the name is accepted but ignored.
+     */
     echoLibraryKeyName?: pulumi.Input<string>;
 
-    /** Echo library access key value (password) for the library remotes. */
+    /** Echo library access key value (password/token) for the library remotes. */
     echoLibraryKeyValue?: pulumi.Input<string>;
 
-    /** @default "https://pypi.echohq.com" */
+    /**
+     * PyPI remote URL. Alone among the ecosystems it carries the "/simple"
+     * suffix (PEP 503 simple index); npm/Maven point at the index root.
+     * @default "https://pypi.echohq.com/simple"
+     */
     echoPypiUrl?: string;
 
     /** @default "https://npm.echohq.com" */
@@ -197,6 +205,11 @@ export class JfrogIntegration extends pulumi.ComponentResource {
             instructions.push(`Images:  docker pull <your-jfrog-domain>/${imageRepository}/static:latest`);
         }
 
+        // Library remotes (PyPI / npm / Maven) authenticate to Echo by token
+        // only: the key value is the password and `username` (the key name) is a
+        // no-op, accepted for parity with images but ignored by Echo's index.
+        // These repo types have no `enableTokenAuthentication` toggle (Docker
+        // only), so there is nothing further to set.
         const libraryCommon = {
             username: args.echoLibraryKeyName ?? "",
             password: args.echoLibraryKeyValue ?? "",
@@ -215,7 +228,7 @@ export class JfrogIntegration extends pulumi.ComponentResource {
             const key = args.echoPypiRepositoryName || `${repositoryName}-pypi`;
             new artifactory.RemotePypiRepository(`${name}-pypi`, {
                 key,
-                url: args.echoPypiUrl || "https://pypi.echohq.com",
+                url: args.echoPypiUrl || "https://pypi.echohq.com/simple",
                 ...libraryCommon,
             }, { parent: this });
             instructions.push(`PyPI:    pip install --index-url https://<your-jfrog-domain>/artifactory/api/pypi/${key}/simple <package>`);

--- a/echo-terraform-gar-mirror/README.md
+++ b/echo-terraform-gar-mirror/README.md
@@ -48,6 +48,8 @@ terraform init && terraform apply
   Docker remote using the image fields.
 
 ### Libraries (package registries — one shared library key)
+> **Disabled for now.** The library proxy resources are commented out in `main.tf`; these inputs are accepted but provision nothing until libraries are turned on.
+
 - `echo_library_pypi` / `echo_library_npm` / `echo_library_maven` (bool, default: `false`)
 - `echo_library_key_name` / `echo_library_key_value` (string, sensitive) — library access key
 - `echo_library_key_secret_name` (string, default: `"echo-gar-mirror-library-secret"`) — Secret Manager secret name for the library key

--- a/echo-terraform-gar-mirror/main.tf
+++ b/echo-terraform-gar-mirror/main.tf
@@ -10,21 +10,23 @@ locals {
   # deprecated access key was supplied.
   create_docker = var.create && (var.echo_images || nonsensitive(var.echo_access_key_name) != "")
 
-  # Provision the library secret only when at least one library format is on.
-  create_library = var.create && (var.echo_library_pypi || var.echo_library_npm || var.echo_library_maven)
+  # Library remotes are disabled for now. Library locals + resources below are
+  # commented out; re-enable them when libraries are turned on.
+  # create_library = var.create && (var.echo_library_pypi || var.echo_library_npm || var.echo_library_maven)
 
   # Per-format repository ids (overridable, otherwise derived from the base).
   image_repository = var.echo_image_repository_name != "" ? var.echo_image_repository_name : var.repository_name
-  pypi_repository  = var.echo_pypi_repository_name != "" ? var.echo_pypi_repository_name : "${var.repository_name}-pypi"
-  npm_repository   = var.echo_npm_repository_name != "" ? var.echo_npm_repository_name : "${var.repository_name}-npm"
-  maven_repository = var.echo_maven_repository_name != "" ? var.echo_maven_repository_name : "${var.repository_name}-maven"
+  # pypi_repository  = var.echo_pypi_repository_name != "" ? var.echo_pypi_repository_name : "${var.repository_name}-pypi"
+  # npm_repository   = var.echo_npm_repository_name != "" ? var.echo_npm_repository_name : "${var.repository_name}-npm"
+  # maven_repository = var.echo_maven_repository_name != "" ? var.echo_maven_repository_name : "${var.repository_name}-maven"
 
   # Repositories created by this module, used to fan out the IAM bindings.
   created_repositories = merge(
     local.create_docker ? { image = google_artifact_registry_repository.echo_remote_repo[0] } : {},
-    var.echo_library_pypi ? { pypi = google_artifact_registry_repository.echo_pypi[0] } : {},
-    var.echo_library_npm ? { npm = google_artifact_registry_repository.echo_npm[0] } : {},
-    var.echo_library_maven ? { maven = google_artifact_registry_repository.echo_maven[0] } : {},
+    # Library remotes disabled for now:
+    # var.echo_library_pypi ? { pypi = google_artifact_registry_repository.echo_pypi[0] } : {},
+    # var.echo_library_npm ? { npm = google_artifact_registry_repository.echo_npm[0] } : {},
+    # var.echo_library_maven ? { maven = google_artifact_registry_repository.echo_maven[0] } : {},
   )
 }
 
@@ -83,8 +85,10 @@ resource "google_secret_manager_secret_version" "echo_access_key" {
 
 # ---------------------------------------------------------------------------
 # Secret Manager — library access key (shared across library formats)
+# DISABLED for now — re-enable when libraries are turned on.
 # ---------------------------------------------------------------------------
 
+/*
 resource "google_secret_manager_secret" "echo_library_key" {
   count = local.create_library ? 1 : 0
 
@@ -107,6 +111,7 @@ resource "google_secret_manager_secret_version" "echo_library_key" {
   secret      = google_secret_manager_secret.echo_library_key[0].id
   secret_data = var.echo_library_key_value
 }
+*/
 
 # ---------------------------------------------------------------------------
 # Artifact Registry repositories
@@ -145,6 +150,8 @@ resource "google_artifact_registry_repository" "echo_remote_repo" {
   depends_on = [google_project_service.artifactregistry]
 }
 
+# Library remotes (PyPI / npm / Maven) DISABLED for now.
+/*
 # PyPI (PYTHON) remote repository for Echo's PyPI index
 resource "google_artifact_registry_repository" "echo_pypi" {
   count = var.create && var.echo_library_pypi ? 1 : 0
@@ -243,6 +250,7 @@ resource "google_artifact_registry_repository" "echo_maven" {
 
   depends_on = [google_project_service.artifactregistry]
 }
+*/
 
 # ---------------------------------------------------------------------------
 # IAM — secret accessor for the GAR service account (per created secret)
@@ -258,6 +266,8 @@ resource "google_secret_manager_secret_iam_member" "gar_secret_accessor" {
   depends_on = [google_project_service.artifactregistry]
 }
 
+# Library secret accessor DISABLED for now.
+/*
 resource "google_secret_manager_secret_iam_member" "gar_library_secret_accessor" {
   count = local.create_library ? 1 : 0
 
@@ -267,6 +277,7 @@ resource "google_secret_manager_secret_iam_member" "gar_library_secret_accessor"
 
   depends_on = [google_project_service.artifactregistry]
 }
+*/
 
 # ---------------------------------------------------------------------------
 # IAM — repository reader/writer bindings (applied per created repository)

--- a/echo-terraform-gar-mirror/outputs.tf
+++ b/echo-terraform-gar-mirror/outputs.tf
@@ -13,6 +13,8 @@ output "image_repository_key" {
   value       = local.create_docker ? local.image_repository : null
 }
 
+# Library remotes disabled for now.
+/*
 output "library_repository_keys" {
   description = "Repository ids of the library remotes that were created."
   value = compact([
@@ -21,6 +23,7 @@ output "library_repository_keys" {
     var.echo_library_maven ? local.maven_repository : "",
   ])
 }
+*/
 
 output "secret_id" {
   description = "The ID of the secret containing the Echo image access key, if created."
@@ -32,17 +35,21 @@ output "secret_version" {
   value       = local.create_docker ? google_secret_manager_secret_version.echo_access_key[0].name : null
 }
 
+# Library secret disabled for now.
+/*
 output "library_secret_id" {
   description = "The ID of the secret containing the Echo library access key, if created."
   value       = local.create_library ? google_secret_manager_secret.echo_library_key[0].secret_id : null
 }
+*/
 
 output "usage_instructions" {
   description = "Instructions for using the Echo remote repositories provisioned in GAR."
   value = var.create ? join("\n", compact([
     local.create_docker ? "Images:  docker pull ${var.location}-docker.pkg.dev/${var.project_id}/${local.image_repository}/static:latest" : "",
-    var.echo_library_pypi ? "PyPI:    pip install --index-url https://${var.location}-python.pkg.dev/${var.project_id}/${local.pypi_repository}/simple/ <package>" : "",
-    var.echo_library_npm ? "npm:     npm install --registry https://${var.location}-npm.pkg.dev/${var.project_id}/${local.npm_repository}/ <package>" : "",
-    var.echo_library_maven ? "Maven:   add https://${var.location}-maven.pkg.dev/${var.project_id}/${local.maven_repository} as a repository in your settings.xml" : "",
+    # Library remotes disabled for now:
+    # var.echo_library_pypi ? "PyPI:    pip install --index-url https://${var.location}-python.pkg.dev/${var.project_id}/${local.pypi_repository}/simple/ <package>" : "",
+    # var.echo_library_npm ? "npm:     npm install --registry https://${var.location}-npm.pkg.dev/${var.project_id}/${local.npm_repository}/ <package>" : "",
+    # var.echo_library_maven ? "Maven:   add https://${var.location}-maven.pkg.dev/${var.project_id}/${local.maven_repository} as a repository in your settings.xml" : "",
   ])) : null
 }

--- a/echo-terraform-jfrog-mirror/README.md
+++ b/echo-terraform-jfrog-mirror/README.md
@@ -43,8 +43,12 @@ terraform init && terraform apply
 
 ### Libraries (package registries — one shared library key)
 - `echo_library_pypi` / `echo_library_npm` / `echo_library_maven` (bool, default: `false`)
-- `echo_library_key_name` / `echo_library_key_value` (string, sensitive) — library access key
-- `echo_pypi_url` (default: `"https://pypi.echohq.com"`)
+- `echo_library_key_value` (string, sensitive) — library access key. Authentication
+  is **token-only**: this value is the password.
+- `echo_library_key_name` (string, sensitive) — **no-op**. Accepted so customers can
+  paste the key name they generated, but Echo's library index ignores the username.
+- `echo_pypi_url` (default: `"https://pypi.echohq.com/simple"`) — PyPI is the only
+  ecosystem whose URL carries the `/simple` suffix (PEP 503 simple index)
 - `echo_npm_url` (default: `"https://npm.echohq.com"`)
 - `echo_maven_url` (default: `"https://maven.echohq.com"`)
 - `echo_pypi_repository_name` / `echo_npm_repository_name` / `echo_maven_repository_name`

--- a/echo-terraform-jfrog-mirror/main.tf
+++ b/echo-terraform-jfrog-mirror/main.tf
@@ -56,7 +56,13 @@ resource "artifactory_remote_docker_repository" "echo_remote" {
   property_sets = length(var.property_sets) > 0 ? var.property_sets : ["artifactory"]
 }
 
-# PyPI remote repository for Echo's PyPI index
+# Library remotes (PyPI / npm / Maven) authenticate to Echo by token only: the
+# library key value is the password and `username` (the key name) is a no-op,
+# accepted for parity with the image flow but ignored by Echo's index. Unlike
+# the Docker remote there is no `enable_token_authentication` toggle on these
+# repo types — the provider does not expose it.
+
+# PyPI remote repository for Echo's PyPI index (URL carries the /simple suffix)
 resource "artifactory_remote_pypi_repository" "echo_pypi" {
   count = var.create && var.echo_library_pypi ? 1 : 0
 

--- a/echo-terraform-jfrog-mirror/variables.tf
+++ b/echo-terraform-jfrog-mirror/variables.tf
@@ -86,8 +86,11 @@ variable "echo_library_maven" {
 }
 
 variable "echo_library_key_name" {
-  type        = string
-  description = "Echo library access key name (username) for the library remotes."
+  type = string
+  # Echo's library index authenticates by token only: the key value goes in the
+  # password field and the key name (username) is a no-op. Accepted so customers
+  # can supply the name they generated, but it does not affect authentication.
+  description = "Echo library access key name (username) for the library remotes. No-op — library auth is token-only via echo_library_key_value."
   default     = ""
   sensitive   = true
 }
@@ -101,8 +104,11 @@ variable "echo_library_key_value" {
 
 variable "echo_pypi_url" {
   type        = string
-  description = "URL of the Echo PyPI index."
-  default     = "https://pypi.echohq.com"
+  # PyPI is the only ecosystem whose remote URL carries the "/simple" suffix —
+  # Artifactory proxies Echo's PEP 503 simple index directly. npm/Maven point
+  # at the index root.
+  description = "URL of the Echo PyPI index (PEP 503 simple index, ends in /simple)."
+  default     = "https://pypi.echohq.com/simple"
 }
 
 variable "echo_npm_url" {

--- a/echo-terraform-nexus-mirror/README.md
+++ b/echo-terraform-nexus-mirror/README.md
@@ -44,6 +44,8 @@ terraform init && terraform apply
   compatibility; when set they provision the Docker proxy using the image fields.
 
 ### Libraries (package registries — one shared library key)
+> **Disabled for now.** The library proxy resources are commented out in `main.tf`; these inputs are accepted but provision nothing until libraries are turned on.
+
 - `echo_library_pypi` / `echo_library_npm` / `echo_library_maven` (bool, default: `false`)
 - `echo_library_key_name` / `echo_library_key_value` (string, sensitive) — library access key
 - `echo_pypi_url` (default: `"https://pypi.echohq.com"`)

--- a/echo-terraform-nexus-mirror/main.tf
+++ b/echo-terraform-nexus-mirror/main.tf
@@ -12,9 +12,11 @@ locals {
 
   # Per-format repository keys (overridable, otherwise derived from the base).
   image_repository = var.echo_image_repository_name != "" ? var.echo_image_repository_name : var.repository_name
-  pypi_repository  = var.echo_pypi_repository_name != "" ? var.echo_pypi_repository_name : "${var.repository_name}-pypi"
-  npm_repository   = var.echo_npm_repository_name != "" ? var.echo_npm_repository_name : "${var.repository_name}-npm"
-  maven_repository = var.echo_maven_repository_name != "" ? var.echo_maven_repository_name : "${var.repository_name}-maven"
+  # Library proxies are disabled for now; library locals + resources are
+  # commented out below. Re-enable them when libraries are turned on.
+  # pypi_repository  = var.echo_pypi_repository_name != "" ? var.echo_pypi_repository_name : "${var.repository_name}-pypi"
+  # npm_repository   = var.echo_npm_repository_name != "" ? var.echo_npm_repository_name : "${var.repository_name}-npm"
+  # maven_repository = var.echo_maven_repository_name != "" ? var.echo_maven_repository_name : "${var.repository_name}-maven"
 }
 
 # Docker proxy repository for Echo
@@ -88,6 +90,8 @@ resource "nexus_repository_docker_proxy" "echo_proxy" {
 }
 
 
+# Library proxies (PyPI / npm / Maven) DISABLED for now.
+/*
 # PyPI proxy repository for Echo's PyPI index
 resource "nexus_repository_pypi_proxy" "echo_pypi" {
   count = var.create && var.echo_library_pypi ? 1 : 0
@@ -203,6 +207,7 @@ resource "nexus_repository_maven_proxy" "echo_maven" {
 
   routing_rule = var.routing_rule
 }
+*/
 
 # Optional: Create a content selector for the repository
 resource "nexus_security_content_selector" "echo_selector" {

--- a/echo-terraform-nexus-mirror/outputs.tf
+++ b/echo-terraform-nexus-mirror/outputs.tf
@@ -2,9 +2,10 @@ output "usage_instructions" {
   description = "Instructions for using the Echo proxy repositories provisioned in Nexus. Replace <nexus-host> with your Nexus host."
   value = var.create ? join("\n", compact([
     local.create_docker ? "Images:  docker pull <nexus-host>${coalesce(var.docker_http_port, var.docker_https_port) != null ? ":${coalesce(var.docker_http_port, var.docker_https_port)}" : ""}/static:latest" : "",
-    var.echo_library_pypi ? "PyPI:    pip install --index-url https://<nexus-host>/repository/${local.pypi_repository}/simple <package>" : "",
-    var.echo_library_npm ? "npm:     npm install --registry https://<nexus-host>/repository/${local.npm_repository}/ <package>" : "",
-    var.echo_library_maven ? "Maven:   add https://<nexus-host>/repository/${local.maven_repository} as a repository in your settings.xml" : "",
+    # Library proxies disabled for now:
+    # var.echo_library_pypi ? "PyPI:    pip install --index-url https://<nexus-host>/repository/${local.pypi_repository}/simple <package>" : "",
+    # var.echo_library_npm ? "npm:     npm install --registry https://<nexus-host>/repository/${local.npm_repository}/ <package>" : "",
+    # var.echo_library_maven ? "Maven:   add https://<nexus-host>/repository/${local.maven_repository} as a repository in your settings.xml" : "",
   ])) : null
 }
 
@@ -13,6 +14,8 @@ output "image_repository_key" {
   value       = local.create_docker ? local.image_repository : null
 }
 
+# Library proxies disabled for now.
+/*
 output "library_repository_keys" {
   description = "Names of the library proxy repositories that were created."
   value = compact([
@@ -21,3 +24,4 @@ output "library_repository_keys" {
     var.echo_library_maven ? local.maven_repository : "",
   ])
 }
+*/


### PR DESCRIPTION
## What

### JFrog mirrors (terraform + pulumi)
- **PyPI remote URL** now defaults to `https://pypi.echohq.com/simple` (pypi only; npm/Maven point at the index root).
- **Token-only auth documented**: the library key *value* is the password; the key *name* (username) is a **no-op**, accepted for parity with the image flow but ignored by Echo's index. The provider exposes `enable_token_authentication` on the Docker remote only, not on pypi/npm/maven repo types.

### GAR + Nexus mirrors
- **Commented out all library (pypi/npm/maven) resources, locals, and outputs.** Image resources stay active.
- Library **inputs remain defined as no-ops** so existing callers do not hard-error.
- README Libraries sections note they are **disabled for now**.

## Why
JFrog library integrations ship first. GAR/Nexus library provisioning is disabled until those flows are verified per vendor.

## Test
- `terraform fmt -check` passes for `echo-terraform-gar-mirror` and `echo-terraform-nexus-mirror`.
- `tsc --noEmit` passes for `echo-pulumi-gar-mirror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> GAR/Nexus stacks that already enabled library flags will stop managing those repos/secrets on apply (destroy risk); JFrog PyPI default URL change can break existing remotes that relied on the old upstream.
> 
> **Overview**
> **JFrog** Terraform and Pulumi mirror modules keep library remotes active but fix how they talk to Echo: the **PyPI upstream default** is now `https://pypi.echohq.com/simple`, and docs/comments clarify **token-only library auth** (key value = password; key name is ignored).
> 
> **GAR and Nexus** (Terraform + Pulumi for GAR) **disable library provisioning** by commenting out PyPI/npm/Maven resources, related locals, secret/IAM wiring, and several outputs. **Image** Docker remotes/proxies are unchanged. Library **inputs stay** so callers do not break; READMEs call out that library flags are **no-ops until re-enabled**. GAR Pulumi still exposes `libraryRepositoryKeys` as an empty list for output compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 580c4b325766394ce1e54a1e96b18eaa83468132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->