### PR TITLE
fix(jfrog-mirror): drop /simple suffix from Echo PyPI remote URL

### DIFF
--- a/echo-pulumi-jfrog-mirror/README.md
+++ b/echo-pulumi-jfrog-mirror/README.md
@@ -45,9 +45,8 @@ export const usageInstructions = integration.usageInstructions;
   value is the password.
 - `echoLibraryKeyName` — **no-op**. Accepted for parity with the image flow, but Echo's
   library index ignores the username.
-- `echoPypiUrl` (default `https://pypi.echohq.com/simple` — only PyPI carries the
-  `/simple` suffix) / `echoNpmUrl` (default `https://npm.echohq.com`) / `echoMavenUrl`
-  (default `https://maven.echohq.com`)
+- `echoPypiUrl` (default `https://pypi.echohq.com`) / `echoNpmUrl` (default
+  `https://npm.echohq.com`) / `echoMavenUrl` (default `https://maven.echohq.com`)
 - `echoPypiRepositoryName` / `echoNpmRepositoryName` / `echoMavenRepositoryName`
   (default → `<remoteRepositoryName>-{pypi,npm,maven}`)
 

--- a/echo-pulumi-jfrog-mirror/index.ts
+++ b/echo-pulumi-jfrog-mirror/index.ts
@@ -67,9 +67,9 @@ export interface JfrogIntegrationInput {
     echoLibraryKeyValue?: pulumi.Input<string>;
 
     /**
-     * PyPI remote URL. Alone among the ecosystems it carries the "/simple"
-     * suffix (PEP 503 simple index); npm/Maven point at the index root.
-     * @default "https://pypi.echohq.com/simple"
+     * PyPI remote URL. Points at the index root; Artifactory appends the
+     * PEP 503 simple path itself when proxying.
+     * @default "https://pypi.echohq.com"
      */
     echoPypiUrl?: string;
 
@@ -228,7 +228,7 @@ export class JfrogIntegration extends pulumi.ComponentResource {
             const key = args.echoPypiRepositoryName || `${repositoryName}-pypi`;
             new artifactory.RemotePypiRepository(`${name}-pypi`, {
                 key,
-                url: args.echoPypiUrl || "https://pypi.echohq.com/simple",
+                url: args.echoPypiUrl || "https://pypi.echohq.com",
                 ...libraryCommon,
             }, { parent: this });
             instructions.push(`PyPI:    pip install --index-url https://<your-jfrog-domain>/artifactory/api/pypi/${key}/simple <package>`);

--- a/echo-terraform-jfrog-mirror/README.md
+++ b/echo-terraform-jfrog-mirror/README.md
@@ -47,8 +47,7 @@ terraform init && terraform apply
   is **token-only**: this value is the password.
 - `echo_library_key_name` (string, sensitive) — **no-op**. Accepted so customers can
   paste the key name they generated, but Echo's library index ignores the username.
-- `echo_pypi_url` (default: `"https://pypi.echohq.com/simple"`) — PyPI is the only
-  ecosystem whose URL carries the `/simple` suffix (PEP 503 simple index)
+- `echo_pypi_url` (default: `"https://pypi.echohq.com"`)
 - `echo_npm_url` (default: `"https://npm.echohq.com"`)
 - `echo_maven_url` (default: `"https://maven.echohq.com"`)
 - `echo_pypi_repository_name` / `echo_npm_repository_name` / `echo_maven_repository_name`

--- a/echo-terraform-jfrog-mirror/main.tf
+++ b/echo-terraform-jfrog-mirror/main.tf
@@ -62,7 +62,7 @@ resource "artifactory_remote_docker_repository" "echo_remote" {
 # the Docker remote there is no `enable_token_authentication` toggle on these
 # repo types — the provider does not expose it.
 
-# PyPI remote repository for Echo's PyPI index (URL carries the /simple suffix)
+# PyPI remote repository for Echo's PyPI index
 resource "artifactory_remote_pypi_repository" "echo_pypi" {
   count = var.create && var.echo_library_pypi ? 1 : 0
 

--- a/echo-terraform-jfrog-mirror/variables.tf
+++ b/echo-terraform-jfrog-mirror/variables.tf
@@ -104,11 +104,10 @@ variable "echo_library_key_value" {
 
 variable "echo_pypi_url" {
   type        = string
-  # PyPI is the only ecosystem whose remote URL carries the "/simple" suffix —
-  # Artifactory proxies Echo's PEP 503 simple index directly. npm/Maven point
-  # at the index root.
-  description = "URL of the Echo PyPI index (PEP 503 simple index, ends in /simple)."
-  default     = "https://pypi.echohq.com/simple"
+  # All ecosystems point at the index root; Artifactory appends the PEP 503
+  # simple path itself when proxying.
+  description = "URL of the Echo PyPI index."
+  default     = "https://pypi.echohq.com"
 }
 
 variable "echo_npm_url" {


### PR DESCRIPTION
## What
The Echo PyPI remote URL default no longer carries the `/simple` suffix in both the terraform and pulumi JFrog mirror providers. It now points at the index root (`https://pypi.echohq.com`).

## Why
Artifactory appends the PEP 503 simple path itself when proxying a PyPI remote, so `/simple` on the remote URL is redundant.

## Changes
- terraform: `echo_pypi_url` default + description/comments
- pulumi: `echoPypiUrl` default + jsdoc
- READMEs updated
- pip client install endpoint (`.../api/pypi/<repo>/simple`) unchanged

Paired with the matching `platform` UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the default upstream URL can break or fix existing PyPI proxy setups on the next apply if they relied on the old default; overrides are unaffected.
> 
> **Overview**
> **PyPI remote upstream URL** defaults and docs now use the index root (`https://pypi.echohq.com`) instead of `https://pypi.echohq.com/simple` in both **Terraform** (`echo_pypi_url`) and **Pulumi** (`echoPypiUrl`).
> 
> Rationale in comments/README: JFrog Artifactory adds the PEP 503 simple path when proxying, so `/simple` on the remote URL was redundant. **Client-facing** pip install instructions still point at `.../artifactory/api/pypi/<repo>/simple` and are unchanged.
> 
> Deployments that **explicitly** set `echo_pypi_url` / `echoPypiUrl` to the old default keep that value until they update it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2799b1c4ccbdbe73bf1a1b401cc7762ae7433bae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->