### PR TITLE
[ECH-5509][ECH-5510] feat(jfrog,nexus): pypi two-remote+virtual; enable Nexus library proxies

### DIFF
--- a/echo-pulumi-jfrog-mirror/README.md
+++ b/echo-pulumi-jfrog-mirror/README.md
@@ -41,14 +41,33 @@ export const usageInstructions = integration.usageInstructions;
 
 ### Libraries (one shared library key)
 - `echoLibraryPypi` / `echoLibraryNpm` / `echoLibraryMaven` (boolean, default `false`)
-- `echoLibraryKeyValue` — library access key. Authentication is **token-only**: this
-  value is the password.
-- `echoLibraryKeyName` — **no-op**. Accepted for parity with the image flow, but Echo's
-  library index ignores the username.
-- `echoPypiUrl` (default `https://pypi.echohq.com`) / `echoNpmUrl` (default
-  `https://npm.echohq.com`) / `echoMavenUrl` (default `https://maven.echohq.com`)
+- `echoLibraryKeyValue` — library access key value (the Basic-auth password).
+- `echoLibraryKeyName` — the Echo library access key **subject** (deterministic per
+  tenant, `et-<id>`), used as the Basic-auth username. JFrog sends credentials
+  preemptively, so Basic with the correct subject authenticates.
+- `echoNpmUrl` (default `https://npm.echohq.com`) / `echoMavenUrl` (default
+  `https://maven.echohq.com`)
 - `echoPypiRepositoryName` / `echoNpmRepositoryName` / `echoMavenRepositoryName`
   (default → `<remoteRepositoryName>-{pypi,npm,maven}`)
+
+#### PyPI topology
+A pypi remote cannot point at a virtual, so PyPI provisions **two smart remotes
+aggregated by a customer virtual** that pip resolves against:
+- `<pypi>` (virtual) — `repositories: [<pypi>-prod, <pypi>-remote]`; this is the key in
+  the `--index-url`.
+- `<pypi>-prod` (remote) — proxies Echo's first-party local `prod-pypi`.
+- `<pypi>-remote` (remote) — proxies Echo's upstream cache `pypi-remote`.
+
+Each member remote sets both `url` (`<base>/<repo>`) and `pypiRegistryUrl`
+(`<base>/api/pypi/<repo>`); `pypiRepositorySuffix` stays the default `simple`.
+- `echoPypiBaseUrl` (default `https://packages.echohq.com/artifactory`) — host + prefix
+  for the backing repos
+- `echoPypiProdRepo` (default `prod-pypi`) / `echoPypiRemoteRepo` (default `pypi-remote`)
+- `echoPypiUrl` — **deprecated**, the single-remote PyPI URL is no longer used
+
+> The pypi/npm/maven remotes do not expose `enableTokenAuthentication` in the provider
+> (docker-only; jfrog provider issue #1389). If Echo ever requires Bearer, PATCH
+> `{"enableTokenAuthentication":true}` via REST after create.
 
 ### Shared
 - `remoteRepositoryName` (string, default `echo`) — base name; per-format repos derive from it

--- a/echo-pulumi-jfrog-mirror/index.ts
+++ b/echo-pulumi-jfrog-mirror/index.ts
@@ -57,9 +57,10 @@ export interface JfrogIntegrationInput {
     echoLibraryMaven?: boolean;
 
     /**
-     * Echo library access key name (username) for the library remotes. No-op:
-     * Echo's library index authenticates by token only (the key value is the
-     * password), so the name is accepted but ignored.
+     * Echo library access key SUBJECT (deterministic per tenant, `et-<id>`),
+     * used as the Basic-auth username on the library remotes. JFrog sends creds
+     * preemptively, so Basic with the correct subject username authenticates;
+     * this is no longer a no-op. The key value is the password.
      */
     echoLibraryKeyName?: pulumi.Input<string>;
 
@@ -67,11 +68,33 @@ export interface JfrogIntegrationInput {
     echoLibraryKeyValue?: pulumi.Input<string>;
 
     /**
-     * PyPI remote URL. Points at the index root; Artifactory appends the
-     * PEP 503 simple path itself when proxying.
-     * @default "https://pypi.echohq.com"
+     * @deprecated PyPI no longer uses a single remote. The PyPI topology is now
+     * two smart remotes (against Echo's first-party `prod-pypi` local and the
+     * `pypi-remote` upstream cache) aggregated by a customer virtual that pip
+     * resolves against. Configure via echoPypiBaseUrl / echoPypiProdRepo /
+     * echoPypiRemoteRepo instead.
      */
     echoPypiUrl?: string;
+
+    /**
+     * Host + `/artifactory` prefix for Echo's backing PyPI repositories. Each
+     * member remote derives its plain `url` (`<base>/<repo>`) and
+     * `pypiRegistryUrl` (`<base>/api/pypi/<repo>`) from it.
+     * @default "https://packages.echohq.com/artifactory"
+     */
+    echoPypiBaseUrl?: string;
+
+    /**
+     * Echo first-party PyPI local repo proxied by the `<pypi>-prod` member remote.
+     * @default "prod-pypi"
+     */
+    echoPypiProdRepo?: string;
+
+    /**
+     * Echo upstream PyPI cache repo proxied by the `<pypi>-remote` member remote.
+     * @default "pypi-remote"
+     */
+    echoPypiRemoteRepo?: string;
 
     /** @default "https://npm.echohq.com" */
     echoNpmUrl?: string;
@@ -224,14 +247,42 @@ export class JfrogIntegration extends pulumi.ComponentResource {
         };
 
         // --- Library remotes ---
+        // PyPI: a pypi remote cannot point at a virtual, so proxy each Echo
+        // backing repo with its own smart remote and aggregate them under a
+        // customer virtual that pip resolves against. A pypi remote needs both
+        // `url` (plain) and `pypiRegistryUrl` (with api/pypi). Auth is Basic
+        // (username = library key subject, password = key value); JFrog sends
+        // creds preemptively. The pypi/npm/maven remotes do not expose
+        // enableTokenAuthentication in the provider (docker-only; jfrog provider
+        // issue #1389) — if Echo ever requires Bearer, the workaround is a
+        // post-create REST PATCH {"enableTokenAuthentication":true}.
         if (args.echoLibraryPypi) {
-            const key = args.echoPypiRepositoryName || `${repositoryName}-pypi`;
-            new artifactory.RemotePypiRepository(`${name}-pypi`, {
-                key,
-                url: args.echoPypiUrl || "https://pypi.echohq.com",
+            const pypiKey = args.echoPypiRepositoryName || `${repositoryName}-pypi`;
+            const prodKey = `${pypiKey}-prod`;
+            const remoteKey = `${pypiKey}-remote`;
+            const base = args.echoPypiBaseUrl || "https://packages.echohq.com/artifactory";
+            const prodRepo = args.echoPypiProdRepo || "prod-pypi";
+            const remoteRepo = args.echoPypiRemoteRepo || "pypi-remote";
+
+            new artifactory.RemotePypiRepository(`${name}-pypi-prod`, {
+                key: prodKey,
+                url: `${base}/${prodRepo}`,
+                pypiRegistryUrl: `${base}/api/pypi/${prodRepo}`,
                 ...libraryCommon,
             }, { parent: this });
-            instructions.push(`PyPI:    pip install --index-url https://<your-jfrog-domain>/artifactory/api/pypi/${key}/simple <package>`);
+            new artifactory.RemotePypiRepository(`${name}-pypi-remote`, {
+                key: remoteKey,
+                url: `${base}/${remoteRepo}`,
+                pypiRegistryUrl: `${base}/api/pypi/${remoteRepo}`,
+                ...libraryCommon,
+            }, { parent: this });
+            new artifactory.VirtualPypiRepository(`${name}-pypi`, {
+                key: pypiKey,
+                repositories: [prodKey, remoteKey],
+                description,
+                notes,
+            }, { parent: this });
+            instructions.push(`PyPI:    pip install --index-url https://<your-jfrog-domain>/artifactory/api/pypi/${pypiKey}/simple <package>`);
         }
 
         if (args.echoLibraryNpm) {

--- a/echo-pulumi-jfrog-mirror/index.ts
+++ b/echo-pulumi-jfrog-mirror/index.ts
@@ -264,24 +264,28 @@ export class JfrogIntegration extends pulumi.ComponentResource {
             const prodRepo = args.echoPypiProdRepo || "prod-pypi";
             const remoteRepo = args.echoPypiRemoteRepo || "pypi-remote";
 
-            new artifactory.RemotePypiRepository(`${name}-pypi-prod`, {
+            const pypiProd = new artifactory.RemotePypiRepository(`${name}-pypi-prod`, {
                 key: prodKey,
                 url: `${base}/${prodRepo}`,
                 pypiRegistryUrl: `${base}/api/pypi/${prodRepo}`,
                 ...libraryCommon,
             }, { parent: this });
-            new artifactory.RemotePypiRepository(`${name}-pypi-remote`, {
+            const pypiRemote = new artifactory.RemotePypiRepository(`${name}-pypi-remote`, {
                 key: remoteKey,
                 url: `${base}/${remoteRepo}`,
                 pypiRegistryUrl: `${base}/api/pypi/${remoteRepo}`,
                 ...libraryCommon,
             }, { parent: this });
+            // The virtual references the two remotes by key (plain strings), so
+            // Pulumi can't infer the dependency; dependsOn forces the members to
+            // exist before the virtual is created (Artifactory rejects a virtual
+            // that lists not-yet-created members). Mirrors the Terraform depends_on.
             new artifactory.VirtualPypiRepository(`${name}-pypi`, {
                 key: pypiKey,
                 repositories: [prodKey, remoteKey],
                 description,
                 notes,
-            }, { parent: this });
+            }, { parent: this, dependsOn: [pypiProd, pypiRemote] });
             instructions.push(`PyPI:    pip install --index-url https://<your-jfrog-domain>/artifactory/api/pypi/${pypiKey}/simple <package>`);
         }
 

--- a/echo-terraform-jfrog-mirror/README.md
+++ b/echo-terraform-jfrog-mirror/README.md
@@ -43,15 +43,24 @@ terraform init && terraform apply
 
 ### Libraries (package registries — one shared library key)
 - `echo_library_pypi` / `echo_library_npm` / `echo_library_maven` (bool, default: `false`)
-- `echo_library_key_value` (string, sensitive) — library access key. Authentication
-  is **token-only**: this value is the password.
-- `echo_library_key_name` (string, sensitive) — **no-op**. Accepted so customers can
-  paste the key name they generated, but Echo's library index ignores the username.
-- `echo_pypi_url` (default: `"https://pypi.echohq.com"`)
+- `echo_library_key_value` (string, sensitive) — library access key (the password).
+- `echo_library_key_name` (string, sensitive) — the Echo library access-key **subject**
+  (`et-<id>`) used as the Basic auth username. Required: JFrog remotes send credentials
+  preemptively, so the correct subject authenticates.
+- `echo_pypi_base_url` (default: `"https://packages.echohq.com/artifactory"`) — Echo host
+  backing the PyPI remotes
+- `echo_pypi_prod_repo` (default: `"prod-pypi"`) — Echo first-party local repo
+- `echo_pypi_remote_repo` (default: `"pypi-remote"`) — Echo upstream cache repo
+- `echo_pypi_url` — **deprecated**, replaced by `echo_pypi_base_url` + the repo split
 - `echo_npm_url` (default: `"https://npm.echohq.com"`)
 - `echo_maven_url` (default: `"https://maven.echohq.com"`)
 - `echo_pypi_repository_name` / `echo_npm_repository_name` / `echo_maven_repository_name`
   (string, default: `""` → `<remote_repository_name>-{pypi,npm,maven}`)
+
+> **PyPI topology:** a JFrog pypi remote cannot point at a virtual, so enabling
+> `echo_library_pypi` creates **two smart remotes** (`<pypi>-prod`, `<pypi>-remote`)
+> aggregated by **one virtual** (`<pypi>`). pip resolves against the virtual. npm and
+> Maven remain single smart remotes.
 
 ### Shared
 - `create` (bool, default: `true`)

--- a/echo-terraform-jfrog-mirror/main.tf
+++ b/echo-terraform-jfrog-mirror/main.tf
@@ -15,6 +15,11 @@ locals {
   pypi_repository  = var.echo_pypi_repository_name != "" ? var.echo_pypi_repository_name : "${var.remote_repository_name}-pypi"
   npm_repository   = var.echo_npm_repository_name != "" ? var.echo_npm_repository_name : "${var.remote_repository_name}-npm"
   maven_repository = var.echo_maven_repository_name != "" ? var.echo_maven_repository_name : "${var.remote_repository_name}-maven"
+
+  # PyPI member-remote keys: the virtual (pypi_repository, what pip resolves
+  # against) aggregates these two smart remotes.
+  pypi_prod_repository   = "${local.pypi_repository}-prod"
+  pypi_remote_repository = "${local.pypi_repository}-remote"
 }
 
 # Docker remote repository for Echo's image registry
@@ -56,22 +61,33 @@ resource "artifactory_remote_docker_repository" "echo_remote" {
   property_sets = length(var.property_sets) > 0 ? var.property_sets : ["artifactory"]
 }
 
-# Library remotes (PyPI / npm / Maven) authenticate to Echo by token only: the
-# library key value is the password and `username` (the key name) is a no-op,
-# accepted for parity with the image flow but ignored by Echo's index. Unlike
-# the Docker remote there is no `enable_token_authentication` toggle on these
-# repo types — the provider does not expose it.
+# Library remotes (PyPI / npm / Maven) authenticate to Echo with Basic auth: the
+# username is the library access-key SUBJECT (echo_library_key_name, "et-<id>")
+# and the password is the key value. JFrog remotes send credentials preemptively,
+# so the correct subject username authenticates. Unlike the Docker remote there
+# is no `enable_token_authentication` toggle on these repo types — the provider
+# does not expose it (docker-only; jfrog provider issue #1389). If Echo requires
+# Bearer instead of Basic, the workaround is a post-create REST PATCH against the
+# repo config with {"enableTokenAuthentication":true}.
 
-# PyPI remote repository for Echo's PyPI index
-resource "artifactory_remote_pypi_repository" "echo_pypi" {
+# PyPI topology: a JFrog pypi *remote* cannot point at a virtual, so we create
+# two smart remotes (one per Echo backing repo) and a customer *virtual* that
+# aggregates them. pip resolves against the virtual:
+#   pip install --index-url .../artifactory/api/pypi/<virtual>/simple <pkg>
+# A pypi remote has two URL fields: `url` (plain, no api/pypi) and
+# `pypi_registry_url` (with api/pypi).
+
+# PyPI smart remote proxying Echo's first-party local repo
+resource "artifactory_remote_pypi_repository" "echo_pypi_prod" {
   count = var.create && var.echo_library_pypi ? 1 : 0
 
-  key         = local.pypi_repository
-  url         = var.echo_pypi_url
-  username    = var.echo_library_key_name
-  password    = var.echo_library_key_value
-  description = var.description
-  notes       = var.notes
+  key               = local.pypi_prod_repository
+  url               = "${var.echo_pypi_base_url}/${var.echo_pypi_prod_repo}"
+  pypi_registry_url = "${var.echo_pypi_base_url}/api/pypi/${var.echo_pypi_prod_repo}"
+  username          = var.echo_library_key_name
+  password          = var.echo_library_key_value
+  description       = var.description
+  notes             = var.notes
 
   store_artifacts_locally        = var.store_artifacts_locally
   socket_timeout_millis          = var.socket_timeout_millis
@@ -79,6 +95,42 @@ resource "artifactory_remote_pypi_repository" "echo_pypi" {
   missed_cache_period_seconds    = var.missed_cache_period_seconds
   hard_fail                      = var.hard_fail
   offline                        = var.offline
+}
+
+# PyPI smart remote proxying Echo's upstream cache repo
+resource "artifactory_remote_pypi_repository" "echo_pypi_remote" {
+  count = var.create && var.echo_library_pypi ? 1 : 0
+
+  key               = local.pypi_remote_repository
+  url               = "${var.echo_pypi_base_url}/${var.echo_pypi_remote_repo}"
+  pypi_registry_url = "${var.echo_pypi_base_url}/api/pypi/${var.echo_pypi_remote_repo}"
+  username          = var.echo_library_key_name
+  password          = var.echo_library_key_value
+  description       = var.description
+  notes             = var.notes
+
+  store_artifacts_locally        = var.store_artifacts_locally
+  socket_timeout_millis          = var.socket_timeout_millis
+  retrieval_cache_period_seconds = var.retrieval_cache_period_seconds
+  missed_cache_period_seconds    = var.missed_cache_period_seconds
+  hard_fail                      = var.hard_fail
+  offline                        = var.offline
+}
+
+# Customer-facing PyPI virtual that pip resolves against, aggregating the two
+# smart remotes above (prod first, then the upstream cache).
+resource "artifactory_virtual_pypi_repository" "echo_pypi" {
+  count = var.create && var.echo_library_pypi ? 1 : 0
+
+  key          = local.pypi_repository
+  repositories = [local.pypi_prod_repository, local.pypi_remote_repository]
+  description  = var.description
+  notes        = var.notes
+
+  depends_on = [
+    artifactory_remote_pypi_repository.echo_pypi_prod,
+    artifactory_remote_pypi_repository.echo_pypi_remote,
+  ]
 }
 
 # npm remote repository for Echo's npm index

--- a/echo-terraform-jfrog-mirror/variables.tf
+++ b/echo-terraform-jfrog-mirror/variables.tf
@@ -87,10 +87,10 @@ variable "echo_library_maven" {
 
 variable "echo_library_key_name" {
   type = string
-  # Echo's library index authenticates by token only: the key value goes in the
-  # password field and the key name (username) is a no-op. Accepted so customers
-  # can supply the name they generated, but it does not affect authentication.
-  description = "Echo library access key name (username) for the library remotes. No-op — library auth is token-only via echo_library_key_value."
+  # The Echo library access-key SUBJECT (deterministic per tenant, "et-<id>").
+  # JFrog remotes send credentials preemptively, so Basic auth with this subject
+  # as the username and echo_library_key_value as the password authenticates.
+  description = "Echo library access key SUBJECT (et-<id>) used as the Basic auth username for the library remotes."
   default     = ""
   sensitive   = true
 }
@@ -102,12 +102,32 @@ variable "echo_library_key_value" {
   sensitive   = true
 }
 
+# Deprecated: replaced by the base-url + repo split (echo_pypi_base_url plus
+# echo_pypi_prod_repo / echo_pypi_remote_repo). PyPI now resolves through a
+# customer virtual that aggregates two smart remotes, so a single index URL no
+# longer describes the topology.
 variable "echo_pypi_url" {
   type        = string
-  # All ecosystems point at the index root; Artifactory appends the PEP 503
-  # simple path itself when proxying.
-  description = "URL of the Echo PyPI index."
+  description = "Deprecated. Replaced by echo_pypi_base_url + echo_pypi_prod_repo/echo_pypi_remote_repo. URL of the Echo PyPI index."
   default     = "https://pypi.echohq.com"
+}
+
+variable "echo_pypi_base_url" {
+  type        = string
+  description = "Base URL of the Echo Artifactory host that backs the PyPI remotes. The prod/remote repo paths are appended to it."
+  default     = "https://packages.echohq.com/artifactory"
+}
+
+variable "echo_pypi_prod_repo" {
+  type        = string
+  description = "Echo first-party local PyPI repo proxied by the echo-pypi-prod smart remote."
+  default     = "prod-pypi"
+}
+
+variable "echo_pypi_remote_repo" {
+  type        = string
+  description = "Echo upstream cache PyPI repo proxied by the echo-pypi-remote smart remote."
+  default     = "pypi-remote"
 }
 
 variable "echo_npm_url" {

--- a/echo-terraform-nexus-mirror/README.md
+++ b/echo-terraform-nexus-mirror/README.md
@@ -44,10 +44,18 @@ terraform init && terraform apply
   compatibility; when set they provision the Docker proxy using the image fields.
 
 ### Libraries (package registries — one shared library key)
-> **Disabled for now.** The library proxy resources are commented out in `main.tf`; these inputs are accepted but provision nothing until libraries are turned on.
+> Library proxies are provisioned with Basic/token auth. Each enabled format
+> creates a single Nexus proxy repository authenticated with the Echo library
+> access key. **Preemptive caveat:** Echo's library hosts never issue a 401
+> challenge, so they require *preemptive* auth. The `datadrivers/nexus`
+> provider cannot set Preemptive Bearer Token and exposes the `preemptive`
+> flag only on the Maven proxy, so this module uses plain Basic auth and does
+> not enable preemptive yet. Turning it on is a follow-up handled out-of-band
+> (e.g. a Nexus REST call); see datadrivers/nexus PR #586.
 
 - `echo_library_pypi` / `echo_library_npm` / `echo_library_maven` (bool, default: `false`)
-- `echo_library_key_name` / `echo_library_key_value` (string, sensitive) — library access key
+- `echo_library_key_name` (string, sensitive) — Basic auth username, the Echo library access-key subject (`et-<id>`)
+- `echo_library_key_value` (string, sensitive) — Basic auth password, the library access token
 - `echo_pypi_url` (default: `"https://pypi.echohq.com"`)
 - `echo_npm_url` (default: `"https://npm.echohq.com"`)
 - `echo_maven_url` (default: `"https://maven.echohq.com"`)

--- a/echo-terraform-nexus-mirror/main.tf
+++ b/echo-terraform-nexus-mirror/main.tf
@@ -12,11 +12,9 @@ locals {
 
   # Per-format repository keys (overridable, otherwise derived from the base).
   image_repository = var.echo_image_repository_name != "" ? var.echo_image_repository_name : var.repository_name
-  # Library proxies are disabled for now; library locals + resources are
-  # commented out below. Re-enable them when libraries are turned on.
-  # pypi_repository  = var.echo_pypi_repository_name != "" ? var.echo_pypi_repository_name : "${var.repository_name}-pypi"
-  # npm_repository   = var.echo_npm_repository_name != "" ? var.echo_npm_repository_name : "${var.repository_name}-npm"
-  # maven_repository = var.echo_maven_repository_name != "" ? var.echo_maven_repository_name : "${var.repository_name}-maven"
+  pypi_repository  = var.echo_pypi_repository_name != "" ? var.echo_pypi_repository_name : "${var.repository_name}-pypi"
+  npm_repository   = var.echo_npm_repository_name != "" ? var.echo_npm_repository_name : "${var.repository_name}-npm"
+  maven_repository = var.echo_maven_repository_name != "" ? var.echo_maven_repository_name : "${var.repository_name}-maven"
 }
 
 # Docker proxy repository for Echo
@@ -90,8 +88,19 @@ resource "nexus_repository_docker_proxy" "echo_proxy" {
 }
 
 
-# Library proxies (PyPI / npm / Maven) DISABLED for now.
-/*
+# Library proxies (PyPI / npm / Maven).
+#
+# AUTH CAVEAT (read before changing the authentication blocks below):
+# Echo's library hosts require *preemptive* auth - they never issue a 401
+# challenge, so Nexus must send credentials on the first request. The
+# datadrivers/nexus provider (v2.8.0) cannot configure Preemptive Bearer Token
+# auth at all, and exposes the `preemptive` boolean only on maven_proxy (not
+# pypi/npm). We therefore use plain Basic (`type = "username"`) auth here and do
+# NOT set `preemptive` on any block for now. Enabling preemptive auth is a
+# follow-up that must happen out-of-band (e.g. a Nexus REST call) until the
+# provider gains support. See datadrivers/nexus PR #586 (npm bearer token) and
+# the manual REST/UI flow for the preemptive toggle.
+
 # PyPI proxy repository for Echo's PyPI index
 resource "nexus_repository_pypi_proxy" "echo_pypi" {
   count = var.create && var.echo_library_pypi ? 1 : 0
@@ -119,6 +128,9 @@ resource "nexus_repository_pypi_proxy" "echo_pypi" {
     blocked    = var.http_client_blocked
     auto_block = var.http_client_auto_block
 
+    # Basic/token auth (Echo subject + access token). Preemptive auth is
+    # required by Echo but not settable via this provider for pypi - see the
+    # AUTH CAVEAT above.
     authentication {
       type     = "username"
       username = var.echo_library_key_name
@@ -156,6 +168,9 @@ resource "nexus_repository_npm_proxy" "echo_npm" {
     blocked    = var.http_client_blocked
     auto_block = var.http_client_auto_block
 
+    # Basic/token auth (Echo subject + access token). Preemptive auth is
+    # required by Echo but not settable via this provider for npm - see the
+    # AUTH CAVEAT above.
     authentication {
       type     = "username"
       username = var.echo_library_key_name
@@ -198,6 +213,10 @@ resource "nexus_repository_maven_proxy" "echo_maven" {
     blocked    = var.http_client_blocked
     auto_block = var.http_client_auto_block
 
+    # Basic/token auth (Echo subject + access token). Preemptive auth is
+    # required by Echo but not enabled here - see the AUTH CAVEAT above. Maven
+    # has a preemptive-basic variant in the provider, but we leave `preemptive`
+    # unset for now and toggle it out-of-band.
     authentication {
       type     = "username"
       username = var.echo_library_key_name
@@ -207,7 +226,6 @@ resource "nexus_repository_maven_proxy" "echo_maven" {
 
   routing_rule = var.routing_rule
 }
-*/
 
 # Optional: Create a content selector for the repository
 resource "nexus_security_content_selector" "echo_selector" {

--- a/echo-terraform-nexus-mirror/outputs.tf
+++ b/echo-terraform-nexus-mirror/outputs.tf
@@ -2,10 +2,9 @@ output "usage_instructions" {
   description = "Instructions for using the Echo proxy repositories provisioned in Nexus. Replace <nexus-host> with your Nexus host."
   value = var.create ? join("\n", compact([
     local.create_docker ? "Images:  docker pull <nexus-host>${coalesce(var.docker_http_port, var.docker_https_port) != null ? ":${coalesce(var.docker_http_port, var.docker_https_port)}" : ""}/static:latest" : "",
-    # Library proxies disabled for now:
-    # var.echo_library_pypi ? "PyPI:    pip install --index-url https://<nexus-host>/repository/${local.pypi_repository}/simple <package>" : "",
-    # var.echo_library_npm ? "npm:     npm install --registry https://<nexus-host>/repository/${local.npm_repository}/ <package>" : "",
-    # var.echo_library_maven ? "Maven:   add https://<nexus-host>/repository/${local.maven_repository} as a repository in your settings.xml" : "",
+    var.echo_library_pypi ? "PyPI:    pip install --index-url https://<nexus-host>/repository/${local.pypi_repository}/simple <package>" : "",
+    var.echo_library_npm ? "npm:     npm install --registry https://<nexus-host>/repository/${local.npm_repository}/ <package>" : "",
+    var.echo_library_maven ? "Maven:   add https://<nexus-host>/repository/${local.maven_repository} as a repository in your settings.xml" : "",
   ])) : null
 }
 
@@ -14,8 +13,6 @@ output "image_repository_key" {
   value       = local.create_docker ? local.image_repository : null
 }
 
-# Library proxies disabled for now.
-/*
 output "library_repository_keys" {
   description = "Names of the library proxy repositories that were created."
   value = compact([
@@ -24,4 +21,3 @@ output "library_repository_keys" {
     var.echo_library_maven ? local.maven_repository : "",
   ])
 }
-*/

--- a/echo-terraform-nexus-mirror/variables.tf
+++ b/echo-terraform-nexus-mirror/variables.tf
@@ -73,7 +73,7 @@ variable "echo_library_maven" {
 
 variable "echo_library_key_name" {
   type        = string
-  description = "Echo library access key name (username) for the library proxies - get this from the Echo platform"
+  description = "Basic auth username for the library proxies: the Echo library access-key subject (et-<id>). Get this from the Echo platform."
   sensitive   = true
   default     = ""
 }


### PR DESCRIPTION
Aligns the JFrog + Nexus IaC mirror modules with the validated manual integration steps. Companion to platform PR #1342 (UI steps + flags + the `et-<id>` subject wiring). Relates to ECH-5509, ECH-5510.

> Branched off `fix/jfrog-pypi-remote-drop-simple`, so it includes the prior `2799b1c` pypi-URL commit; the pypi rework below supersedes that single-remote approach.

## JFrog (terraform + pulumi)
A JFrog pypi remote cannot resolve through a virtual repository, so pypi now provisions **two smart remotes + a customer virtual**:
- `echo-pypi-prod` → Echo `prod-pypi` (first-party local)
- `echo-pypi-remote` → Echo `pypi-remote` (upstream cache)
- `artifactory_virtual_pypi_repository` / `VirtualPypiRepository` `echo-pypi` aggregating both (pip resolves against this)

pypi remotes use the two-field `url` + `pypi_registry_url` scheme (host `packages.echohq.com/artifactory`; `api/pypi` only on the registry url). **npm/maven unchanged** (single smart remote each). New defaulted, override-only vars: `echo_pypi_base_url`, `echo_pypi_prod_repo`, `echo_pypi_remote_repo`.

## Nexus (terraform)
Enabled the previously commented-out **pypi/npm/maven proxies** with token (Basic) auth (`type="username"`, `username=et-<id>`, `password=token`). Image proxy untouched.

## Auth notes
- Library auth username is the deterministic Echo access-key subject `et-<id>` (was a no-op placeholder).
- **JFrog**: the provider exposes no `enable_token_authentication` on pypi/npm/maven remotes (provider issue #1389). JFrog sends Basic preemptively, so this works if Echo accepts Basic; if Bearer is required, apply a post-create REST `PATCH {"enableTokenAuthentication":true}`.
- **Nexus**: `preemptive` is intentionally unset — `datadrivers/nexus` v2.8.0 cannot set Preemptive Bearer Token and exposes `preemptive` only on `maven_proxy`. Echo never 401-challenges, so preemptive must be enabled out-of-band (Nexus REST/UI) as a follow-up; tracked alongside datadrivers PR #586.

## UI contract
The module-input contract the UI copy-paste snippet writes is **unchanged** (`echo_library_pypi/npm/maven` toggles + `echo_library_key_name`/`value`). The pypi rework is entirely module-internal.

## Verification
- `terraform fmt` + `terraform validate` pass on both TF modules (jfrog provider 12.11.5, nexus 2.8.0 from lockfiles).
- `tsc --noEmit` passes on the pulumi component (`@pulumi/artifactory` 8.8.5 exports `VirtualPypiRepository` + `pypiRegistryUrl`).

## Migration note
Existing applied stacks: the JFrog `echo-pypi` repo changes type (single remote → virtual) and Pulumi's `${name}-pypi` URN changes resource type, so Terraform/Pulumi will replace it. Re-apply against fresh or accept the replace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes customer Artifactory/Nexus repository topology and library authentication semantics; JFrog PyPI enablement replaces existing repos on re-apply, and Nexus library proxies may fail until preemptive auth is configured manually.
> 
> **Overview**
> **JFrog (Terraform + Pulumi)** replaces the single PyPI smart remote with **two member remotes** (`<pypi>-prod`, `<pypi>-remote`) pointing at Echo’s `prod-pypi` and `pypi-remote` on `packages.echohq.com/artifactory`, plus a **customer virtual** (`<pypi>`) that pip uses. New override inputs are `echo_pypi_base_url` / `echo_pypi_prod_repo` / `echo_pypi_remote_repo`; `echo_pypi_url` is deprecated. Library auth is documented as **Basic** with `echo_library_key_name` as the `et-<id>` subject (no longer a no-op). npm/Maven stay single remotes.
> 
> **Nexus (Terraform)** turns on the previously disabled **PyPI/npm/Maven proxies** with Basic auth (`et-<id>` + token), restores `usage_instructions` / `library_repository_keys` for libraries, and documents that **preemptive** auth must be enabled out-of-band because the Nexus provider cannot set it for pypi/npm.
> 
> Existing JFrog stacks that already applied the old single `echo-pypi` remote should expect a **replace** (remote → virtual plus new member repos).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc5df698c080ae0e1ae0100f3a686f12865d7113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->