### PR TITLE
[ECH-5264] feat(gar): enable library mirror IaC (PyPI/npm/maven)

### DIFF
--- a/echo-pulumi-gar-mirror/README.md
+++ b/echo-pulumi-gar-mirror/README.md
@@ -45,7 +45,6 @@ export const usage = remote.usageInstructions;
   compatibility; provisions the Docker remote when set.
 
 ### Libraries (package registries — one shared library key)
-> **Disabled for now.** The library remotes are commented out in `index.ts`; these inputs are accepted but provision nothing until libraries are turned on.
 
 - `echoLibraryPypi` / `echoLibraryNpm` / `echoLibraryMaven` (boolean, default: `false`)
 - `echoLibraryKeyName` / `echoLibraryKeyValue` (Input<string>, secret) — library access key

--- a/echo-pulumi-gar-mirror/index.ts
+++ b/echo-pulumi-gar-mirror/index.ts
@@ -212,8 +212,7 @@ export class GcpGarRemote extends pulumi.ComponentResource {
         const repositoryName = args.repositoryName || "echo";
         const description = args.description || "Remote repository for Echo Registry integration";
         const imageSecretName = args.echoAccessKeySecretName || "echo-gar-mirror-secret";
-        // Libraries disabled for now.
-        // const librarySecretName = args.echoLibraryKeySecretName || "echo-gar-mirror-library-secret";
+        const librarySecretName = args.echoLibraryKeySecretName || "echo-gar-mirror-library-secret";
 
         const labels = { ...args.labels };
 
@@ -298,12 +297,11 @@ export class GcpGarRemote extends pulumi.ComponentResource {
         }
 
         // --- Library remotes (one shared library key) ---
-        // DISABLED for now. The library remotes below are commented out;
-        // re-enable them when libraries are turned on. The empty
-        // `libraryRepositoryKeys` keeps the output contract intact ([] for now).
+        // Each remote authenticates to Echo with the shared library key
+        // (username = echoLibraryKeyName, password from the library secret);
+        // GAR delivers the credentials to the upstream natively.
         const libraryRepositoryKeys: pulumi.Output<string>[] = [];
 
-        /*
         const createLibrary = args.echoLibraryPypi === true || args.echoLibraryNpm === true || args.echoLibraryMaven === true;
 
         if (createLibrary) {
@@ -414,7 +412,6 @@ export class GcpGarRemote extends pulumi.ComponentResource {
                 instructions.push(`Maven:   add https://${location}-maven.pkg.dev/${args.projectId}/${key} as a repository in your settings.xml`);
             }
         }
-        */
 
         // Create IAM bindings for repository readers/writers across all created
         // repos. The first repo (the image remote, index 0) keeps the unindexed

--- a/echo-terraform-gar-mirror/README.md
+++ b/echo-terraform-gar-mirror/README.md
@@ -48,7 +48,6 @@ terraform init && terraform apply
   Docker remote using the image fields.
 
 ### Libraries (package registries — one shared library key)
-> **Disabled for now.** The library proxy resources are commented out in `main.tf`; these inputs are accepted but provision nothing until libraries are turned on.
 
 - `echo_library_pypi` / `echo_library_npm` / `echo_library_maven` (bool, default: `false`)
 - `echo_library_key_name` / `echo_library_key_value` (string, sensitive) — library access key

--- a/echo-terraform-gar-mirror/main.tf
+++ b/echo-terraform-gar-mirror/main.tf
@@ -10,23 +10,21 @@ locals {
   # deprecated access key was supplied.
   create_docker = var.create && (var.echo_images || nonsensitive(var.echo_access_key_name) != "")
 
-  # Library remotes are disabled for now. Library locals + resources below are
-  # commented out; re-enable them when libraries are turned on.
-  # create_library = var.create && (var.echo_library_pypi || var.echo_library_npm || var.echo_library_maven)
+  # Provision the library secret only when at least one library format is on.
+  create_library = var.create && (var.echo_library_pypi || var.echo_library_npm || var.echo_library_maven)
 
   # Per-format repository ids (overridable, otherwise derived from the base).
   image_repository = var.echo_image_repository_name != "" ? var.echo_image_repository_name : var.repository_name
-  # pypi_repository  = var.echo_pypi_repository_name != "" ? var.echo_pypi_repository_name : "${var.repository_name}-pypi"
-  # npm_repository   = var.echo_npm_repository_name != "" ? var.echo_npm_repository_name : "${var.repository_name}-npm"
-  # maven_repository = var.echo_maven_repository_name != "" ? var.echo_maven_repository_name : "${var.repository_name}-maven"
+  pypi_repository  = var.echo_pypi_repository_name != "" ? var.echo_pypi_repository_name : "${var.repository_name}-pypi"
+  npm_repository   = var.echo_npm_repository_name != "" ? var.echo_npm_repository_name : "${var.repository_name}-npm"
+  maven_repository = var.echo_maven_repository_name != "" ? var.echo_maven_repository_name : "${var.repository_name}-maven"
 
   # Repositories created by this module, used to fan out the IAM bindings.
   created_repositories = merge(
     local.create_docker ? { image = google_artifact_registry_repository.echo_remote_repo[0] } : {},
-    # Library remotes disabled for now:
-    # var.echo_library_pypi ? { pypi = google_artifact_registry_repository.echo_pypi[0] } : {},
-    # var.echo_library_npm ? { npm = google_artifact_registry_repository.echo_npm[0] } : {},
-    # var.echo_library_maven ? { maven = google_artifact_registry_repository.echo_maven[0] } : {},
+    var.echo_library_pypi ? { pypi = google_artifact_registry_repository.echo_pypi[0] } : {},
+    var.echo_library_npm ? { npm = google_artifact_registry_repository.echo_npm[0] } : {},
+    var.echo_library_maven ? { maven = google_artifact_registry_repository.echo_maven[0] } : {},
   )
 }
 
@@ -85,10 +83,8 @@ resource "google_secret_manager_secret_version" "echo_access_key" {
 
 # ---------------------------------------------------------------------------
 # Secret Manager — library access key (shared across library formats)
-# DISABLED for now — re-enable when libraries are turned on.
 # ---------------------------------------------------------------------------
 
-/*
 resource "google_secret_manager_secret" "echo_library_key" {
   count = local.create_library ? 1 : 0
 
@@ -111,7 +107,6 @@ resource "google_secret_manager_secret_version" "echo_library_key" {
   secret      = google_secret_manager_secret.echo_library_key[0].id
   secret_data = var.echo_library_key_value
 }
-*/
 
 # ---------------------------------------------------------------------------
 # Artifact Registry repositories
@@ -150,8 +145,10 @@ resource "google_artifact_registry_repository" "echo_remote_repo" {
   depends_on = [google_project_service.artifactregistry]
 }
 
-# Library remotes (PyPI / npm / Maven) DISABLED for now.
-/*
+# Library remotes (PyPI / npm / Maven). Each remote authenticates to Echo with
+# the shared library key (username = echo_library_key_name, password from the
+# library secret); GAR delivers the credentials to the upstream natively.
+
 # PyPI (PYTHON) remote repository for Echo's PyPI index
 resource "google_artifact_registry_repository" "echo_pypi" {
   count = var.create && var.echo_library_pypi ? 1 : 0
@@ -250,7 +247,6 @@ resource "google_artifact_registry_repository" "echo_maven" {
 
   depends_on = [google_project_service.artifactregistry]
 }
-*/
 
 # ---------------------------------------------------------------------------
 # IAM — secret accessor for the GAR service account (per created secret)
@@ -266,8 +262,6 @@ resource "google_secret_manager_secret_iam_member" "gar_secret_accessor" {
   depends_on = [google_project_service.artifactregistry]
 }
 
-# Library secret accessor DISABLED for now.
-/*
 resource "google_secret_manager_secret_iam_member" "gar_library_secret_accessor" {
   count = local.create_library ? 1 : 0
 
@@ -277,7 +271,6 @@ resource "google_secret_manager_secret_iam_member" "gar_library_secret_accessor"
 
   depends_on = [google_project_service.artifactregistry]
 }
-*/
 
 # ---------------------------------------------------------------------------
 # IAM — repository reader/writer bindings (applied per created repository)

--- a/echo-terraform-gar-mirror/outputs.tf
+++ b/echo-terraform-gar-mirror/outputs.tf
@@ -13,8 +13,6 @@ output "image_repository_key" {
   value       = local.create_docker ? local.image_repository : null
 }
 
-# Library remotes disabled for now.
-/*
 output "library_repository_keys" {
   description = "Repository ids of the library remotes that were created."
   value = compact([
@@ -23,7 +21,6 @@ output "library_repository_keys" {
     var.echo_library_maven ? local.maven_repository : "",
   ])
 }
-*/
 
 output "secret_id" {
   description = "The ID of the secret containing the Echo image access key, if created."
@@ -35,21 +32,17 @@ output "secret_version" {
   value       = local.create_docker ? google_secret_manager_secret_version.echo_access_key[0].name : null
 }
 
-# Library secret disabled for now.
-/*
 output "library_secret_id" {
   description = "The ID of the secret containing the Echo library access key, if created."
   value       = local.create_library ? google_secret_manager_secret.echo_library_key[0].secret_id : null
 }
-*/
 
 output "usage_instructions" {
   description = "Instructions for using the Echo remote repositories provisioned in GAR."
   value = var.create ? join("\n", compact([
     local.create_docker ? "Images:  docker pull ${var.location}-docker.pkg.dev/${var.project_id}/${local.image_repository}/static:latest" : "",
-    # Library remotes disabled for now:
-    # var.echo_library_pypi ? "PyPI:    pip install --index-url https://${var.location}-python.pkg.dev/${var.project_id}/${local.pypi_repository}/simple/ <package>" : "",
-    # var.echo_library_npm ? "npm:     npm install --registry https://${var.location}-npm.pkg.dev/${var.project_id}/${local.npm_repository}/ <package>" : "",
-    # var.echo_library_maven ? "Maven:   add https://${var.location}-maven.pkg.dev/${var.project_id}/${local.maven_repository} as a repository in your settings.xml" : "",
+    var.echo_library_pypi ? "PyPI:    pip install --index-url https://${var.location}-python.pkg.dev/${var.project_id}/${local.pypi_repository}/simple/ <package>" : "",
+    var.echo_library_npm ? "npm:     npm install --registry https://${var.location}-npm.pkg.dev/${var.project_id}/${local.npm_repository}/ <package>" : "",
+    var.echo_library_maven ? "Maven:   add https://${var.location}-maven.pkg.dev/${var.project_id}/${local.maven_repository} as a repository in your settings.xml" : "",
   ])) : null
 }


### PR DESCRIPTION
## What

Re-enable the GAR (Google Artifact Registry) library mirror resources (PyPI / npm / Maven) in both the Terraform and Pulumi modules. They were written in #9, then disabled in #11 (`f03421c`) alongside Nexus while JFrog went out first. Nexus and JFrog libraries shipped this week, so GAR is next.

This mirrors the Nexus re-enable in #13 (`17286b6`).

## Changes

**`echo-terraform-gar-mirror`**
- `main.tf`: uncomment `create_library` local, per-format repository locals, `created_repositories` library entries, the shared library Secret Manager secret + version, the three PYTHON/NPM/MAVEN remote repositories, and the library secret IAM accessor.
- `outputs.tf`: uncomment `library_repository_keys`, `library_secret_id`, and the pip/npm/maven `usage_instructions` lines.

**`echo-pulumi-gar-mirror`**
- `index.ts`: uncomment `librarySecretName` and the full library remote block.

**READMEs**: drop the "Disabled for now" notes.

## Notes / design

- **Auth**: GAR-native `upstream_credentials.username_password_credentials` (username = `echo_library_key_name`, password from the library secret). GCP delivers credentials to the upstream, so there is **no** preemptive-auth provider caveat like Nexus had.
- **PyPI**: GAR uses a single native PYTHON remote to `pypi.echohq.com`. The JFrog two-remote + virtual workaround does not apply here.
- URL defaults (`pypi/npm/maven.echohq.com`) unchanged. Module input contract unchanged (inputs were already accepted as no-ops).
- **UI unchanged**: the GAR library surface stays gated behind the `garLibraryIntegrations` flag (ECH-5386). This PR just makes the Terraform/Pulumi tabs resolve to a module that actually provisions the library remotes.

## Validation

- `terraform fmt -check` clean, `terraform validate` -> Success
- `tsc --noEmit` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turning on library flags creates new secrets, IAM, and remote repos in customer GCP projects; risk is bounded because behavior is opt-in via existing booleans and mirrors the prior Nexus re-enable pattern.
> 
> **Overview**
> Re-enables **Echo library mirroring** in the Terraform and Pulumi GAR modules by uncommenting logic that was previously disabled. When `echo_library_pypi` / `echo_library_npm` / `echo_library_maven` (or the Pulumi equivalents) are set, the modules now provision a **shared library Secret Manager secret**, **PYTHON/NPM/MAVEN remote Artifact Registry repos** pointing at Echo upstreams, and the **GAR service account secret accessor** for that key; library repos are included in **reader/writer IAM** fan-out and in **outputs** (`library_repository_keys`, `library_secret_id`, pip/npm/maven usage lines).
> 
> **READMEs** no longer say library inputs are accepted but provision nothing. The input contract is unchanged—only deployments that turn library flags on will see new infrastructure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c36558ed12bddbe95eea9219c6e014d25fa78a94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->