### PR TITLE
[ECH-5662] fix(gar): point npm remote at packages.echohq.com tarball host

### DIFF
--- a/echo-pulumi-gar-mirror/README.md
+++ b/echo-pulumi-gar-mirror/README.md
@@ -50,7 +50,7 @@ export const usage = remote.usageInstructions;
 - `echoLibraryKeyName` / `echoLibraryKeyValue` (Input<string>, secret) — library access key
 - `echoLibraryKeySecretName` (string, default: `echo-gar-mirror-library-secret`) — Secret Manager secret name for the library key
 - `echoPypiUrl` (default: `https://pypi.echohq.com`)
-- `echoNpmUrl` (default: `https://npm.echohq.com`)
+- `echoNpmUrl` (default: `https://packages.echohq.com/artifactory/api/npm/npm` — GAR requires the npm upstream to be the host that serves the tarballs)
 - `echoMavenUrl` (default: `https://maven.echohq.com`)
 - `echoPypiRepositoryName` / `echoNpmRepositoryName` / `echoMavenRepositoryName`
   (string, default: `""` → `<repositoryName>-{pypi,npm,maven}`)

--- a/echo-pulumi-gar-mirror/index.ts
+++ b/echo-pulumi-gar-mirror/index.ts
@@ -96,7 +96,12 @@ export interface GcpGarRemoteInput {
     /** @default "https://pypi.echohq.com" */
     echoPypiUrl?: string;
 
-    /** @default "https://npm.echohq.com" */
+    /**
+     * GAR rewrites tarball URLs in npm metadata and rejects hosts that differ
+     * from the upstream; Echo npm metadata serves tarballs from
+     * packages.echohq.com, so the remote must point there (not npm.echohq.com).
+     * @default "https://packages.echohq.com/artifactory/api/npm/npm"
+     */
     echoNpmUrl?: string;
 
     /** @default "https://maven.echohq.com" */
@@ -371,10 +376,10 @@ export class GcpGarRemote extends pulumi.ComponentResource {
                     mode: "REMOTE_REPOSITORY",
                     description: description,
                     remoteRepositoryConfig: {
-                        description: "Remote repository pointing to Echo npm (npm.echohq.com)",
+                        description: "Remote repository pointing to Echo npm (packages.echohq.com)",
                         npmRepository: {
                             customRepository: {
-                                uri: args.echoNpmUrl || "https://npm.echohq.com",
+                                uri: args.echoNpmUrl || "https://packages.echohq.com/artifactory/api/npm/npm",
                             },
                         },
                         upstreamCredentials: libraryUpstreamCredentials,

--- a/echo-terraform-gar-mirror/README.md
+++ b/echo-terraform-gar-mirror/README.md
@@ -53,7 +53,7 @@ terraform init && terraform apply
 - `echo_library_key_name` / `echo_library_key_value` (string, sensitive) — library access key
 - `echo_library_key_secret_name` (string, default: `"echo-gar-mirror-library-secret"`) — Secret Manager secret name for the library key
 - `echo_pypi_url` (default: `"https://pypi.echohq.com"`)
-- `echo_npm_url` (default: `"https://npm.echohq.com"`)
+- `echo_npm_url` (default: `"https://packages.echohq.com/artifactory/api/npm/npm"` — GAR requires the npm upstream to be the host that serves the tarballs)
 - `echo_maven_url` (default: `"https://maven.echohq.com"`)
 - `echo_pypi_repository_name` / `echo_npm_repository_name` / `echo_maven_repository_name`
   (string, default: `""` → `<repository_name>-{pypi,npm,maven}`)

--- a/echo-terraform-gar-mirror/main.tf
+++ b/echo-terraform-gar-mirror/main.tf
@@ -194,7 +194,7 @@ resource "google_artifact_registry_repository" "echo_npm" {
   mode          = "REMOTE_REPOSITORY"
 
   remote_repository_config {
-    description = "Remote repository pointing to Echo npm (npm.echohq.com)"
+    description = "Remote repository pointing to Echo npm (packages.echohq.com)"
 
     npm_repository {
       custom_repository {

--- a/echo-terraform-gar-mirror/variables.tf
+++ b/echo-terraform-gar-mirror/variables.tf
@@ -159,9 +159,12 @@ variable "echo_pypi_url" {
 }
 
 variable "echo_npm_url" {
+  # GAR rewrites tarball URLs in npm metadata and rejects hosts that differ
+  # from the upstream; Echo npm metadata serves tarballs from
+  # packages.echohq.com, so the remote must point there (not npm.echohq.com).
   description = "URL of the Echo npm index."
   type        = string
-  default     = "https://npm.echohq.com"
+  default     = "https://packages.echohq.com/artifactory/api/npm/npm"
 
   validation {
     condition     = can(regex("^https://", var.echo_npm_url))


### PR DESCRIPTION
## Why

GAR remote npm repositories rewrite tarball URLs in package metadata and reject metadata whose tarball URLs live on a different host than the configured upstream (HTTP 400 "Request contains an invalid argument"). Echo npm metadata serves tarballs from `packages.echohq.com`, while the configured upstream was `npm.echohq.com` — so every `npm install` through a GAR mirror failed on metadata resolution.

## What

Default npm upstream for the GAR mirror (terraform `echo_npm_url`, pulumi `echoNpmUrl`) changed:

`https://npm.echohq.com` → `https://packages.echohq.com/artifactory/api/npm/npm`

GAR-only change — `npm.echohq.com` remains correct for direct npm clients and the JFrog/Nexus mirrors.

## Verification

Tested in `echo-lab-458314` (us-east1):
- Old upstream: metadata GET → 400 from GAR; control repo with NPMJS upstream worked, isolating the cross-host tarball URLs as the cause.
- New upstream: `npm install lodash` succeeded end-to-end through both a manually created repo and a repo provisioned by this terraform module with defaults.
- pypi/maven unaffected (verified pulls still work).

Linear: ECH-5662

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default infrastructure for npm GAR remotes and will update live Artifact Registry upstream config on apply; scope is limited to npm defaults and is a targeted fix for a known failure mode.
> 
> **Overview**
> Fixes broken **npm installs through GAR mirrors** by changing the default Echo npm upstream from `https://npm.echohq.com` to `https://packages.echohq.com/artifactory/api/npm/npm` in both **Terraform** (`echo_npm_url`) and **Pulumi** (`echoNpmUrl`).
> 
> GAR rejects npm metadata when tarball URLs use a different host than the configured upstream; Echo serves tarballs from `packages.echohq.com`, so the remote must match that host. Docs and inline comments explain the constraint; npm remote descriptions now reference `packages.echohq.com`. **JFrog/Nexus mirrors are unchanged** — they still default to `npm.echohq.com`.
> 
> Deployments that relied on the old default will get an **in-place upstream URI update** on the next apply (unless they override the variable).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b02e54baff01508f40754833525f78cf11f7062c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->