### PR TITLE
feat(jfrog-mirror): collapse pypi to single smart remote [ECH-5896]

### DIFF
--- a/echo-pulumi-jfrog-mirror/README.md
+++ b/echo-pulumi-jfrog-mirror/README.md
@@ -51,19 +51,26 @@ export const usageInstructions = integration.usageInstructions;
   (default → `<remoteRepositoryName>-{pypi,npm,maven}`)
 
 #### PyPI topology
-A pypi remote cannot point at a virtual, so PyPI provisions **two smart remotes
-aggregated by a customer virtual** that pip resolves against:
-- `<pypi>` (virtual) — `repositories: [<pypi>-prod, <pypi>-remote]`; this is the key in
-  the `--index-url`.
-- `<pypi>-prod` (remote) — proxies Echo's first-party local `prod-pypi`.
-- `<pypi>-remote` (remote) — proxies Echo's upstream cache `pypi-remote`.
+JFrog now supports a pypi remote whose upstream is a virtual, so PyPI is a
+**single smart remote** (like npm and Maven) pointing at Echo's virtual `pypi`
+that pip resolves against:
+- `<pypi>` (remote) — URL `https://packages.echohq.com/artifactory/pypi`, Registry URL
+  `https://packages.echohq.com/artifactory/api/pypi/pypi`; this is the key in the
+  `--index-url`.
 
-Each member remote sets both `url` (`<base>/<repo>`) and `pypiRegistryUrl`
+The remote sets both `url` (`<base>/<repo>`) and `pypiRegistryUrl`
 (`<base>/api/pypi/<repo>`); `pypiRepositorySuffix` stays the default `simple`.
 - `echoPypiBaseUrl` (default `https://packages.echohq.com/artifactory`) — host + prefix
-  for the backing repos
-- `echoPypiProdRepo` (default `prod-pypi`) / `echoPypiRemoteRepo` (default `pypi-remote`)
-- `echoPypiUrl` — **deprecated**, the single-remote PyPI URL is no longer used
+  for the backing repo
+- `echoPypiRepo` (default `pypi`) — Echo pypi repository path segment
+- `echoPypiUrl` — **deprecated**, the standalone PyPI index URL is no longer used
+
+> **Migrating from the two-remote topology:** the old layout created remotes
+> `<pypi>-prod` and `<pypi>-remote` plus a virtual `<pypi>`. Upgrading, Pulumi
+> destroys all three and creates remote `<pypi>`. Because the old virtual and the
+> new remote share the same key, destroy the virtual first (e.g.
+> `pulumi destroy --target '**-pypi'` for the virtual) so the new remote's key is
+> free, or run the update twice.
 
 > The pypi/npm/maven remotes do not expose `enableTokenAuthentication` in the provider
 > (docker-only; jfrog provider issue #1389). If Echo ever requires Bearer, PATCH

--- a/echo-pulumi-jfrog-mirror/index.ts
+++ b/echo-pulumi-jfrog-mirror/index.ts
@@ -68,33 +68,25 @@ export interface JfrogIntegrationInput {
     echoLibraryKeyValue?: pulumi.Input<string>;
 
     /**
-     * @deprecated PyPI no longer uses a single remote. The PyPI topology is now
-     * two smart remotes (against Echo's first-party `prod-pypi` local and the
-     * `pypi-remote` upstream cache) aggregated by a customer virtual that pip
-     * resolves against. Configure via echoPypiBaseUrl / echoPypiProdRepo /
-     * echoPypiRemoteRepo instead.
+     * @deprecated PyPI no longer uses a standalone index URL. The PyPI topology
+     * is now a single smart remote pointing at Echo's `pypi` virtual. Configure
+     * via echoPypiBaseUrl / echoPypiRepo instead.
      */
     echoPypiUrl?: string;
 
     /**
-     * Host + `/artifactory` prefix for Echo's backing PyPI repositories. Each
-     * member remote derives its plain `url` (`<base>/<repo>`) and
-     * `pypiRegistryUrl` (`<base>/api/pypi/<repo>`) from it.
+     * Host + `/artifactory` prefix for Echo's backing PyPI repository. The remote
+     * derives its plain `url` (`<base>/<repo>`) and `pypiRegistryUrl`
+     * (`<base>/api/pypi/<repo>`) from it.
      * @default "https://packages.echohq.com/artifactory"
      */
     echoPypiBaseUrl?: string;
 
     /**
-     * Echo first-party PyPI local repo proxied by the `<pypi>-prod` member remote.
-     * @default "prod-pypi"
+     * Echo pypi repository path segment proxied by the PyPI smart remote.
+     * @default "pypi"
      */
-    echoPypiProdRepo?: string;
-
-    /**
-     * Echo upstream PyPI cache repo proxied by the `<pypi>-remote` member remote.
-     * @default "pypi-remote"
-     */
-    echoPypiRemoteRepo?: string;
+    echoPypiRepo?: string;
 
     /** @default "https://npm.echohq.com" */
     echoNpmUrl?: string;
@@ -247,45 +239,26 @@ export class JfrogIntegration extends pulumi.ComponentResource {
         };
 
         // --- Library remotes ---
-        // PyPI: a pypi remote cannot point at a virtual, so proxy each Echo
-        // backing repo with its own smart remote and aggregate them under a
-        // customer virtual that pip resolves against. A pypi remote needs both
-        // `url` (plain) and `pypiRegistryUrl` (with api/pypi). Auth is Basic
-        // (username = library key subject, password = key value); JFrog sends
-        // creds preemptively. The pypi/npm/maven remotes do not expose
+        // PyPI: JFrog now supports a pypi remote whose upstream is a virtual, so
+        // PyPI is a single smart remote (like npm/Maven) pointing at Echo's `pypi`
+        // virtual that pip resolves against. A pypi remote needs both `url`
+        // (plain) and `pypiRegistryUrl` (with api/pypi). Auth is Basic (username =
+        // library key subject, password = key value); JFrog sends creds
+        // preemptively. The pypi/npm/maven remotes do not expose
         // enableTokenAuthentication in the provider (docker-only; jfrog provider
         // issue #1389) — if Echo ever requires Bearer, the workaround is a
         // post-create REST PATCH {"enableTokenAuthentication":true}.
         if (args.echoLibraryPypi) {
             const pypiKey = args.echoPypiRepositoryName || `${repositoryName}-pypi`;
-            const prodKey = `${pypiKey}-prod`;
-            const remoteKey = `${pypiKey}-remote`;
             const base = args.echoPypiBaseUrl || "https://packages.echohq.com/artifactory";
-            const prodRepo = args.echoPypiProdRepo || "prod-pypi";
-            const remoteRepo = args.echoPypiRemoteRepo || "pypi-remote";
+            const repo = args.echoPypiRepo || "pypi";
 
-            const pypiProd = new artifactory.RemotePypiRepository(`${name}-pypi-prod`, {
-                key: prodKey,
-                url: `${base}/${prodRepo}`,
-                pypiRegistryUrl: `${base}/api/pypi/${prodRepo}`,
-                ...libraryCommon,
-            }, { parent: this });
-            const pypiRemote = new artifactory.RemotePypiRepository(`${name}-pypi-remote`, {
-                key: remoteKey,
-                url: `${base}/${remoteRepo}`,
-                pypiRegistryUrl: `${base}/api/pypi/${remoteRepo}`,
-                ...libraryCommon,
-            }, { parent: this });
-            // The virtual references the two remotes by key (plain strings), so
-            // Pulumi can't infer the dependency; dependsOn forces the members to
-            // exist before the virtual is created (Artifactory rejects a virtual
-            // that lists not-yet-created members). Mirrors the Terraform depends_on.
-            new artifactory.VirtualPypiRepository(`${name}-pypi`, {
+            new artifactory.RemotePypiRepository(`${name}-pypi`, {
                 key: pypiKey,
-                repositories: [prodKey, remoteKey],
-                description,
-                notes,
-            }, { parent: this, dependsOn: [pypiProd, pypiRemote] });
+                url: `${base}/${repo}`,
+                pypiRegistryUrl: `${base}/api/pypi/${repo}`,
+                ...libraryCommon,
+            }, { parent: this });
             instructions.push(`PyPI:    pip install --index-url https://<your-jfrog-domain>/artifactory/api/pypi/${pypiKey}/simple <package>`);
         }
 

--- a/echo-terraform-jfrog-mirror/README.md
+++ b/echo-terraform-jfrog-mirror/README.md
@@ -48,19 +48,31 @@ terraform init && terraform apply
   (`et-<id>`) used as the Basic auth username. Required: JFrog remotes send credentials
   preemptively, so the correct subject authenticates.
 - `echo_pypi_base_url` (default: `"https://packages.echohq.com/artifactory"`) — Echo host
-  backing the PyPI remotes
-- `echo_pypi_prod_repo` (default: `"prod-pypi"`) — Echo first-party local repo
-- `echo_pypi_remote_repo` (default: `"pypi-remote"`) — Echo upstream cache repo
-- `echo_pypi_url` — **deprecated**, replaced by `echo_pypi_base_url` + the repo split
+  backing the PyPI remote
+- `echo_pypi_repo` (default: `"pypi"`) — Echo pypi repository path segment
+- `echo_pypi_url` — **deprecated**, replaced by `echo_pypi_base_url` + `echo_pypi_repo`
 - `echo_npm_url` (default: `"https://npm.echohq.com"`)
 - `echo_maven_url` (default: `"https://maven.echohq.com"`)
 - `echo_pypi_repository_name` / `echo_npm_repository_name` / `echo_maven_repository_name`
   (string, default: `""` → `<remote_repository_name>-{pypi,npm,maven}`)
 
-> **PyPI topology:** a JFrog pypi remote cannot point at a virtual, so enabling
-> `echo_library_pypi` creates **two smart remotes** (`<pypi>-prod`, `<pypi>-remote`)
-> aggregated by **one virtual** (`<pypi>`). pip resolves against the virtual. npm and
-> Maven remain single smart remotes.
+> **PyPI topology:** JFrog now supports a pypi remote whose upstream is a virtual,
+> so enabling `echo_library_pypi` creates a **single smart remote** (`<pypi>`) like
+> npm and Maven, pointing at Echo's virtual `pypi`
+> (URL `https://packages.echohq.com/artifactory/pypi`, Registry URL
+> `https://packages.echohq.com/artifactory/api/pypi/pypi`). pip resolves against it.
+>
+> **Migrating from the two-remote topology:** the old layout created remotes
+> `<pypi>-prod` and `<pypi>-remote` plus a virtual `<pypi>`. Upgrading, terraform
+> destroys all three and creates remote `<pypi>`. Because the old virtual and the
+> new remote share the same key, destroy the virtual first so the new remote's
+> key is free:
+>
+> ```bash
+> terraform destroy -target=artifactory_virtual_pypi_repository.echo_pypi
+> ```
+>
+> then `terraform apply` (or simply apply twice).
 
 ### Shared
 - `create` (bool, default: `true`)

--- a/echo-terraform-jfrog-mirror/main.tf
+++ b/echo-terraform-jfrog-mirror/main.tf
@@ -15,11 +15,6 @@ locals {
   pypi_repository  = var.echo_pypi_repository_name != "" ? var.echo_pypi_repository_name : "${var.remote_repository_name}-pypi"
   npm_repository   = var.echo_npm_repository_name != "" ? var.echo_npm_repository_name : "${var.remote_repository_name}-npm"
   maven_repository = var.echo_maven_repository_name != "" ? var.echo_maven_repository_name : "${var.remote_repository_name}-maven"
-
-  # PyPI member-remote keys: the virtual (pypi_repository, what pip resolves
-  # against) aggregates these two smart remotes.
-  pypi_prod_repository   = "${local.pypi_repository}-prod"
-  pypi_remote_repository = "${local.pypi_repository}-remote"
 }
 
 # Docker remote repository for Echo's image registry
@@ -70,20 +65,18 @@ resource "artifactory_remote_docker_repository" "echo_remote" {
 # Bearer instead of Basic, the workaround is a post-create REST PATCH against the
 # repo config with {"enableTokenAuthentication":true}.
 
-# PyPI topology: a JFrog pypi *remote* cannot point at a virtual, so we create
-# two smart remotes (one per Echo backing repo) and a customer *virtual* that
-# aggregates them. pip resolves against the virtual:
-#   pip install --index-url .../artifactory/api/pypi/<virtual>/simple <pkg>
+# PyPI topology: JFrog now supports a pypi *remote* whose upstream is a virtual,
+# so PyPI collapses to a single smart remote (like npm/Maven) pointing at Echo's
+# `pypi` virtual. pip resolves against it:
+#   pip install --index-url .../artifactory/api/pypi/<pypi>/simple <pkg>
 # A pypi remote has two URL fields: `url` (plain, no api/pypi) and
 # `pypi_registry_url` (with api/pypi).
-
-# PyPI smart remote proxying Echo's first-party local repo
-resource "artifactory_remote_pypi_repository" "echo_pypi_prod" {
+resource "artifactory_remote_pypi_repository" "echo_pypi" {
   count = var.create && var.echo_library_pypi ? 1 : 0
 
-  key               = local.pypi_prod_repository
-  url               = "${var.echo_pypi_base_url}/${var.echo_pypi_prod_repo}"
-  pypi_registry_url = "${var.echo_pypi_base_url}/api/pypi/${var.echo_pypi_prod_repo}"
+  key               = local.pypi_repository
+  url               = "${var.echo_pypi_base_url}/${var.echo_pypi_repo}"
+  pypi_registry_url = "${var.echo_pypi_base_url}/api/pypi/${var.echo_pypi_repo}"
   username          = var.echo_library_key_name
   password          = var.echo_library_key_value
   description       = var.description
@@ -95,42 +88,6 @@ resource "artifactory_remote_pypi_repository" "echo_pypi_prod" {
   missed_cache_period_seconds    = var.missed_cache_period_seconds
   hard_fail                      = var.hard_fail
   offline                        = var.offline
-}
-
-# PyPI smart remote proxying Echo's upstream cache repo
-resource "artifactory_remote_pypi_repository" "echo_pypi_remote" {
-  count = var.create && var.echo_library_pypi ? 1 : 0
-
-  key               = local.pypi_remote_repository
-  url               = "${var.echo_pypi_base_url}/${var.echo_pypi_remote_repo}"
-  pypi_registry_url = "${var.echo_pypi_base_url}/api/pypi/${var.echo_pypi_remote_repo}"
-  username          = var.echo_library_key_name
-  password          = var.echo_library_key_value
-  description       = var.description
-  notes             = var.notes
-
-  store_artifacts_locally        = var.store_artifacts_locally
-  socket_timeout_millis          = var.socket_timeout_millis
-  retrieval_cache_period_seconds = var.retrieval_cache_period_seconds
-  missed_cache_period_seconds    = var.missed_cache_period_seconds
-  hard_fail                      = var.hard_fail
-  offline                        = var.offline
-}
-
-# Customer-facing PyPI virtual that pip resolves against, aggregating the two
-# smart remotes above (prod first, then the upstream cache).
-resource "artifactory_virtual_pypi_repository" "echo_pypi" {
-  count = var.create && var.echo_library_pypi ? 1 : 0
-
-  key          = local.pypi_repository
-  repositories = [local.pypi_prod_repository, local.pypi_remote_repository]
-  description  = var.description
-  notes        = var.notes
-
-  depends_on = [
-    artifactory_remote_pypi_repository.echo_pypi_prod,
-    artifactory_remote_pypi_repository.echo_pypi_remote,
-  ]
 }
 
 # npm remote repository for Echo's npm index

--- a/echo-terraform-jfrog-mirror/variables.tf
+++ b/echo-terraform-jfrog-mirror/variables.tf
@@ -103,31 +103,24 @@ variable "echo_library_key_value" {
 }
 
 # Deprecated: replaced by the base-url + repo split (echo_pypi_base_url plus
-# echo_pypi_prod_repo / echo_pypi_remote_repo). PyPI now resolves through a
-# customer virtual that aggregates two smart remotes, so a single index URL no
-# longer describes the topology.
+# echo_pypi_repo). PyPI now resolves through a single smart remote pointing at
+# Echo's virtual, so a standalone index URL no longer describes the topology.
 variable "echo_pypi_url" {
   type        = string
-  description = "Deprecated. Replaced by echo_pypi_base_url + echo_pypi_prod_repo/echo_pypi_remote_repo. URL of the Echo PyPI index."
+  description = "Deprecated. Replaced by echo_pypi_base_url + echo_pypi_repo. URL of the Echo PyPI index."
   default     = "https://pypi.echohq.com"
 }
 
 variable "echo_pypi_base_url" {
   type        = string
-  description = "Base URL of the Echo Artifactory host that backs the PyPI remotes. The prod/remote repo paths are appended to it."
+  description = "Base URL of the Echo Artifactory host that backs the PyPI remote. The repo path is appended to it."
   default     = "https://packages.echohq.com/artifactory"
 }
 
-variable "echo_pypi_prod_repo" {
+variable "echo_pypi_repo" {
   type        = string
-  description = "Echo first-party local PyPI repo proxied by the echo-pypi-prod smart remote."
-  default     = "prod-pypi"
-}
-
-variable "echo_pypi_remote_repo" {
-  type        = string
-  description = "Echo upstream cache PyPI repo proxied by the echo-pypi-remote smart remote."
-  default     = "pypi-remote"
+  description = "Echo pypi repository path segment proxied by the PyPI smart remote."
+  default     = "pypi"
 }
 
 variable "echo_npm_url" {


### PR DESCRIPTION
## Summary

JFrog now supports a pypi remote whose upstream is a virtual. This collapses the PyPI topology in both the Terraform and Pulumi jfrog-mirror modules from two smart remotes plus a customer virtual down to a single smart remote pointing at Echo's `pypi` virtual (URL `https://packages.echohq.com/artifactory/pypi`, Registry URL `https://packages.echohq.com/artifactory/api/pypi/pypi`), matching how npm and Maven are already provisioned.

This is a breaking change for existing pypi users of these modules, since the old virtual and the new remote share the same resource key. See the migration note added to both READMEs (destroy the old virtual first, or apply/update twice).

## Input renames

| Old (Terraform) | Old (Pulumi) | New (Terraform) | New (Pulumi) |
|---|---|---|---|
| `echo_pypi_prod_repo` | `echoPypiProdRepo` | `echo_pypi_repo` (default `"pypi"`) | `echoPypiRepo` (default `"pypi"`) |
| `echo_pypi_remote_repo` | `echoPypiRemoteRepo` | removed | removed |

`echo_pypi_url` / `echoPypiUrl` remain deprecated as before.

## Migration note

The old layout created two remotes (`<pypi>-prod`, `<pypi>-remote`) plus a virtual (`<pypi>`). Upgrading destroys all three and creates a single remote `<pypi>`. Because the old virtual and the new remote share the same key, destroy the virtual first:

```bash
terraform destroy -target=artifactory_virtual_pypi_repository.echo_pypi
```

then `terraform apply` (or simply apply/update twice for Pulumi).

## Related

Companion changes in the platform and documentation repos.

## Test plan
- [ ] `terraform validate` / `terraform plan` against a test tenant
- [ ] `pulumi preview` against a test tenant
- [ ] Verify pip resolves against the new single remote (`pip install --index-url https://<domain>/artifactory/api/pypi/<pypi>/simple <pkg>`)
- [ ] Verify migration path on an existing tenant (destroy virtual first, then apply)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking IaC change for existing PyPI tenants: destroys three Artifactory repos and recreates one, with a key-collision migration path if upgrades are applied blindly.
> 
> **Overview**
> **PyPI in both Terraform and Pulumi jfrog-mirror modules** is simplified from two smart remotes plus a customer virtual to **one smart remote** aimed at Echo’s `pypi` virtual (same pattern as npm/Maven), now that JFrog allows a PyPI remote upstream to be a virtual.
> 
> **Breaking config:** `echo_pypi_prod_repo` / `echo_pypi_remote_repo` (and Pulumi `echoPypiProdRepo` / `echoPypiRemoteRepo`) are removed in favor of **`echo_pypi_repo` / `echoPypiRepo`** (default `pypi`) with `echo_pypi_base_url`. READMEs document upgrade steps because the old virtual and the new remote reuse the same repo key—destroy the virtual first (targeted destroy) or apply/update twice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c7006331337cff51906f0c790073787ac43f361. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->