### PR TITLE
[ECH-6178] feat(jfrog,nexus): mirror Echo's Debian repository for OS packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,16 @@ Infrastructure-as-code templates to integrate container registries with Echo reg
 
 ### JFrog Artifactory
 
+Mirrors images, libraries (PyPI / npm / Maven) and OS packages (Debian).
+
 | Tool | Status | Directory |
 |------|--------|-----------|
 | **Terraform** | ✅ Ready | [`/echo-terraform-jfrog-mirror`](./echo-terraform-jfrog-mirror) |
 | **Pulumi** | ✅ Ready | [`/echo-pulumi-jfrog-mirror`](./echo-pulumi-jfrog-mirror) |
 
 ### Sonatype Nexus Docker Proxy
+
+Mirrors images, libraries (npm / Maven) and OS packages (Debian).
 
 | Tool | Status | Directory |
 |------|--------|-----------|

--- a/echo-pulumi-jfrog-mirror/README.md
+++ b/echo-pulumi-jfrog-mirror/README.md
@@ -1,9 +1,9 @@
 # Echo JFrog Remote Repository - Pulumi Component
 
 Pulumi component that configures JFrog Artifactory as a proxy for Echo. One
-component provisions a Docker remote for **images** and/or PyPI / npm / Maven
-remotes for **libraries**, based on the inputs. Each repository is created only
-when its flag is set.
+component provisions a Docker remote for **images**, PyPI / npm / Maven remotes
+for **libraries** and a Debian remote for **OS packages**, based on the inputs.
+Each repository is created only when its flag is set.
 
 ## Install
 ```bash
@@ -25,6 +25,10 @@ const integration = new JfrogIntegration("echo-integration", {
   echoLibraryNpm: true,
   echoLibraryKeyName: config.requireSecret("echoLibraryKeyName"),
   echoLibraryKeyValue: config.requireSecret("echoLibraryKeyValue"),
+
+  // OS packages
+  echoOsPackages: true,
+  echoOsPackagesUrl: config.require("echoOsPackagesUrl"),
 });
 
 export const usageInstructions = integration.usageInstructions;
@@ -75,6 +79,25 @@ The remote sets both `url` (`<base>/<repo>`) and `pypiRegistryUrl`
 > The pypi/npm/maven remotes do not expose `enableTokenAuthentication` in the provider
 > (docker-only; jfrog provider issue #1389). If Echo ever requires Bearer, PATCH
 > `{"enableTokenAuthentication":true}` via REST after create.
+
+### OS packages (Debian)
+- `echoOsPackages` (boolean, default `false`) — provision the Debian remote
+- `echoOsPackagesUrl` (string) — the Echo Debian repository URL. **Required when
+  `echoOsPackages` is set**; there is intentionally no default, and the component
+  throws if it is missing. Copy it from the Integrations page in the Echo platform.
+- `echoDebRepositoryName` (default → `<remoteRepositoryName>-deb`)
+
+> **Consuming the mirror:** OS package mirroring is supported for **Echo-based
+> images only**. Those images already ship Echo's apt signing key and source, so
+> there is no keyring or `sources.list` setup. In your Dockerfile, swap the
+> source URL to the new remote:
+>
+> ```dockerfile
+> FROM echo/someimage:latest
+> ARG APT_MIRROR=https://<your-jfrog-domain>/artifactory/echo-deb
+> RUN echo-apt-mirror $APT_MIRROR
+> RUN apt-get update && apt-get install -y my-package
+> ```
 
 ### Shared
 - `remoteRepositoryName` (string, default `echo`) — base name; per-format repos derive from it

--- a/echo-pulumi-jfrog-mirror/index.ts
+++ b/echo-pulumi-jfrog-mirror/index.ts
@@ -4,9 +4,10 @@ import * as artifactory from "@pulumi/artifactory";
 /**
  * Configuration options for the JFrog Integration with Echo.
  *
- * One component orchestrates the image (Docker) remote and the library (PyPI /
- * npm / Maven) remotes; each is provisioned only when its flag is set. Images
- * use the image access key, libraries share the library access key.
+ * One component orchestrates the image (Docker) remote, the library (PyPI /
+ * npm / Maven) remotes and the OS packages (Debian) remote; each is provisioned
+ * only when its flag is set. Images use the image access key and libraries
+ * share the library access key.
  */
 export interface JfrogIntegrationInput {
     /**
@@ -103,6 +104,17 @@ export interface JfrogIntegrationInput {
     /** Optional override for the Maven remote key. Defaults to <name>-maven. */
     echoMavenRepositoryName?: string;
 
+    // --- OS packages (Debian) ---
+
+    /** Provision the Debian remote that proxies Echo's Debian repository. */
+    echoOsPackages?: boolean;
+
+    /** URL of the Echo Debian repository. Required when `echoOsPackages` is set. */
+    echoOsPackagesUrl?: string;
+
+    /** Optional override for the Debian remote key. Defaults to <name>-deb. */
+    echoDebRepositoryName?: string;
+
     // --- Shared remote-repository configuration ---
 
     /** @default "Echo remote repository" */
@@ -150,7 +162,8 @@ export interface JfrogIntegrationInput {
  * JFrog Integration Component.
  *
  * Provisions Artifactory remote repositories that proxy Echo — a Docker remote
- * for images and PyPI/npm/Maven remotes for libraries — based on the inputs.
+ * for images, PyPI/npm/Maven remotes for libraries and a Debian remote for OS
+ * packages — based on the inputs.
  *
  * @example
  * ```typescript
@@ -280,6 +293,30 @@ export class JfrogIntegration extends pulumi.ComponentResource {
                 ...libraryCommon,
             }, { parent: this });
             instructions.push(`Maven:   add https://<your-jfrog-domain>/artifactory/${key} as a repository in your settings.xml`);
+        }
+
+        // --- OS packages (Debian) remote ---
+        if (args.echoOsPackages) {
+            if (!args.echoOsPackagesUrl) {
+                throw new Error(
+                    "echoOsPackagesUrl is required when echoOsPackages is enabled. " +
+                    "Copy the repository URL from the Integrations page in the Echo platform.",
+                );
+            }
+            const key = args.echoDebRepositoryName || `${repositoryName}-deb`;
+            new artifactory.RemoteDebianRepository(`${name}-deb`, {
+                key,
+                url: args.echoOsPackagesUrl,
+                description,
+                notes,
+                storeArtifactsLocally,
+                socketTimeoutMillis,
+                retrievalCachePeriodSeconds,
+                missedCachePeriodSeconds,
+                hardFail,
+                offline,
+            }, { parent: this });
+            instructions.push(`OS pkgs: in a Dockerfile built FROM an Echo image, run: echo-apt-mirror https://<your-jfrog-domain>/artifactory/${key}`);
         }
 
         this.usageInstructions = pulumi.output(instructions.join("\n"));

--- a/echo-terraform-jfrog-mirror/README.md
+++ b/echo-terraform-jfrog-mirror/README.md
@@ -1,8 +1,9 @@
 # Echo JFrog Artifactory Mirror - Terraform Module
 
 Configures JFrog Artifactory as a proxy for Echo. One module provisions a Docker
-remote for **images** and/or PyPI / npm / Maven remotes for **libraries**, based
-on the inputs. Each repository is created only when its flag is set.
+remote for **images**, PyPI / npm / Maven remotes for **libraries** and a Debian
+remote for **OS packages**, based on the inputs. Each repository is created only
+when its flag is set.
 
 ## Quickstart
 
@@ -20,6 +21,10 @@ module "echo_jfrog_mirror" {
   echo_library_npm       = true
   echo_library_key_name  = var.echo_library_key_name
   echo_library_key_value = var.echo_library_key_value
+
+  # OS packages (URL comes from the Echo platform)
+  echo_os_packages     = true
+  echo_os_packages_url = var.echo_os_packages_url
 }
 
 output "usage_instructions" {
@@ -74,6 +79,25 @@ terraform init && terraform apply
 >
 > then `terraform apply` (or simply apply twice).
 
+### OS packages (Debian)
+- `echo_os_packages` (bool, default: `false`) — provision the Debian remote
+- `echo_os_packages_url` (string, default: `""`) — the Echo Debian repository URL.
+  **Required when `echo_os_packages` is enabled**; there is intentionally no default.
+  Copy it from the Integrations page in the Echo platform.
+- `echo_deb_repository_name` (string, default: `""` → `<remote_repository_name>-deb`)
+
+> **Consuming the mirror:** OS package mirroring is supported for **Echo-based
+> images only**. Those images already ship Echo's apt signing key and source, so
+> there is no keyring or `sources.list` setup. In your Dockerfile, swap the
+> source URL to the new remote:
+>
+> ```dockerfile
+> FROM echo/someimage:latest
+> ARG APT_MIRROR=https://<your-jfrog-domain>/artifactory/echo-deb
+> RUN echo-apt-mirror $APT_MIRROR
+> RUN apt-get update && apt-get install -y my-package
+> ```
+
 ### Shared
 - `create` (bool, default: `true`)
 - `remote_repository_name` (string, default: `"echo"`) — base name; per-format repos derive from it
@@ -87,6 +111,7 @@ terraform init && terraform apply
 - `usage_instructions` — per-format pull/install instructions (replace `<your-jfrog-domain>`)
 - `image_repository_key` — Docker remote key (or `null`)
 - `library_repository_keys` — list of created library remote keys
+- `os_package_repository_key` — Debian remote key (or `null`)
 
 ## Example — custom repository names
 

--- a/echo-terraform-jfrog-mirror/main.tf
+++ b/echo-terraform-jfrog-mirror/main.tf
@@ -15,6 +15,7 @@ locals {
   pypi_repository  = var.echo_pypi_repository_name != "" ? var.echo_pypi_repository_name : "${var.remote_repository_name}-pypi"
   npm_repository   = var.echo_npm_repository_name != "" ? var.echo_npm_repository_name : "${var.remote_repository_name}-npm"
   maven_repository = var.echo_maven_repository_name != "" ? var.echo_maven_repository_name : "${var.remote_repository_name}-maven"
+  deb_repository   = var.echo_deb_repository_name != "" ? var.echo_deb_repository_name : "${var.remote_repository_name}-deb"
 }
 
 # Docker remote repository for Echo's image registry
@@ -126,4 +127,32 @@ resource "artifactory_remote_maven_repository" "echo_maven" {
   missed_cache_period_seconds    = var.missed_cache_period_seconds
   hard_fail                      = var.hard_fail
   offline                        = var.offline
+}
+
+# Debian remote repository for Echo's OS packages. Consumers are Echo-based
+# images, which already carry Echo's apt signing key and source; they only swap
+# the source URL to point here.
+resource "artifactory_remote_debian_repository" "echo_deb" {
+  count = var.create && var.echo_os_packages ? 1 : 0
+
+  key         = local.deb_repository
+  url         = var.echo_os_packages_url
+  description = var.description
+  notes       = var.notes
+
+  store_artifacts_locally        = var.store_artifacts_locally
+  socket_timeout_millis          = var.socket_timeout_millis
+  retrieval_cache_period_seconds = var.retrieval_cache_period_seconds
+  missed_cache_period_seconds    = var.missed_cache_period_seconds
+  hard_fail                      = var.hard_fail
+  offline                        = var.offline
+
+  # A precondition rather than a variable validation: the rule depends on a
+  # second variable, which validation blocks only support from Terraform 1.9.
+  lifecycle {
+    precondition {
+      condition     = var.echo_os_packages_url != ""
+      error_message = "echo_os_packages_url must be set when echo_os_packages is enabled. Copy the repository URL from the Integrations page in the Echo platform."
+    }
+  }
 }

--- a/echo-terraform-jfrog-mirror/outputs.tf
+++ b/echo-terraform-jfrog-mirror/outputs.tf
@@ -5,6 +5,7 @@ output "usage_instructions" {
     var.echo_library_pypi ? "PyPI:    pip install --index-url https://<your-jfrog-domain>/artifactory/api/pypi/${local.pypi_repository}/simple <package>" : "",
     var.echo_library_npm ? "npm:     npm install --registry https://<your-jfrog-domain>/artifactory/api/npm/${local.npm_repository}/ <package>" : "",
     var.echo_library_maven ? "Maven:   add https://<your-jfrog-domain>/artifactory/${local.maven_repository} as a repository in your settings.xml" : "",
+    var.echo_os_packages ? "OS pkgs: in a Dockerfile built FROM an Echo image, run: echo-apt-mirror https://<your-jfrog-domain>/artifactory/${local.deb_repository}" : "",
   ])) : null
 }
 
@@ -20,4 +21,9 @@ output "library_repository_keys" {
     var.echo_library_npm ? local.npm_repository : "",
     var.echo_library_maven ? local.maven_repository : "",
   ])
+}
+
+output "os_package_repository_key" {
+  description = "Key of the Debian remote repository, if created."
+  value       = var.echo_os_packages ? local.deb_repository : null
 }

--- a/echo-terraform-jfrog-mirror/variables.tf
+++ b/echo-terraform-jfrog-mirror/variables.tf
@@ -154,6 +154,30 @@ variable "echo_maven_repository_name" {
 }
 
 # ---------------------------------------------------------------------------
+# OS packages (Debian)
+# ---------------------------------------------------------------------------
+
+variable "echo_os_packages" {
+  type        = bool
+  description = "Provision the Debian remote repository that proxies Echo's Debian repository."
+  default     = false
+}
+
+# Deliberately has no default: the upstream URL is supplied by the caller. The
+# Echo platform prefills it in the module invocation it generates.
+variable "echo_os_packages_url" {
+  type        = string
+  description = "URL of the Echo Debian repository. Required when echo_os_packages is enabled; copy it from the Integrations page in the Echo platform."
+  default     = ""
+}
+
+variable "echo_deb_repository_name" {
+  type        = string
+  description = "Optional override for the Debian remote repository key. Defaults to <remote_repository_name>-deb."
+  default     = ""
+}
+
+# ---------------------------------------------------------------------------
 # Shared remote-repository configuration
 # ---------------------------------------------------------------------------
 

--- a/echo-terraform-jfrog-mirror/versions.tf
+++ b/echo-terraform-jfrog-mirror/versions.tf
@@ -1,5 +1,6 @@
 terraform {
-  required_version = ">= 1.0"
+  # 1.2 for resource lifecycle preconditions (see the Debian remote in main.tf).
+  required_version = ">= 1.2"
 
   required_providers {
     artifactory = {

--- a/echo-terraform-nexus-mirror/README.md
+++ b/echo-terraform-nexus-mirror/README.md
@@ -1,8 +1,9 @@
 # Echo Nexus Mirror - Terraform Module
 
 Configures Sonatype Nexus as a proxy for Echo. One module provisions a Docker
-proxy for **images** and/or PyPI / npm / Maven proxies for **libraries**, based
-on the inputs. Each repository is created only when its flag is set.
+proxy for **images**, PyPI / npm / Maven proxies for **libraries** and an apt
+proxy for **OS packages**, based on the inputs. Each repository is created only
+when its flag is set.
 
 ## Quickstart
 
@@ -21,6 +22,10 @@ module "echo_nexus_mirror" {
   echo_library_npm       = true
   echo_library_key_name  = var.echo_library_key_name
   echo_library_key_value = var.echo_library_key_value
+
+  # OS packages (URL comes from the Echo platform)
+  echo_os_packages     = true
+  echo_os_packages_url = var.echo_os_packages_url
 }
 
 output "usage_instructions" {
@@ -67,6 +72,29 @@ terraform init && terraform apply
   (string, default: `""` → `<repository_name>-{pypi,npm,maven}`)
 - `maven_version_policy` (string, default: `"MIXED"`) / `maven_layout_policy` (string, default: `"PERMISSIVE"`)
 
+### OS packages (Debian)
+- `echo_os_packages` (bool, default: `false`) — provision the apt proxy
+- `echo_os_packages_url` (string, default: `""`) — the Echo Debian repository URL.
+  **Required when `echo_os_packages` is enabled**; there is intentionally no default.
+  Copy it from the Integrations page in the Echo platform.
+- `echo_deb_repository_name` (string, default: `""` → `<repository_name>-deb`)
+- `echo_os_distribution` (string, default: `""`) — empty proxies every suite. Echo
+  images pin their own suite and only swap the URL prefix, so the proxy has to pass
+  `dists/<suite>/...` through rather than bind to one distribution.
+- `echo_os_flat` (bool, default: `false`) — Echo uses a standard `dists`/`pool` layout
+
+> **Consuming the mirror:** OS package mirroring is supported for **Echo-based
+> images only**. Those images already ship Echo's apt signing key and source, so
+> there is no keyring or `sources.list` setup. In your Dockerfile, swap the
+> source URL to the new proxy:
+>
+> ```dockerfile
+> FROM echo/someimage:latest
+> ARG APT_MIRROR=https://<nexus-host>/repository/echo-deb
+> RUN echo-apt-mirror $APT_MIRROR
+> RUN apt-get update && apt-get install -y my-package
+> ```
+
 ### Shared
 - `create` (bool, default: `true`)
 - `repository_name` (string, default: `"echo"`) — base name; per-format repos derive from it
@@ -80,6 +108,7 @@ terraform init && terraform apply
 - `usage_instructions` — per-format pull/install instructions (replace `<nexus-host>`)
 - `image_repository_key` — Docker proxy name (or `null`)
 - `library_repository_keys` — list of created library proxy names
+- `os_package_repository_key` — apt proxy name (or `null`)
 
 ## Example — custom repository names
 

--- a/echo-terraform-nexus-mirror/main.tf
+++ b/echo-terraform-nexus-mirror/main.tf
@@ -15,6 +15,7 @@ locals {
   pypi_repository  = var.echo_pypi_repository_name != "" ? var.echo_pypi_repository_name : "${var.repository_name}-pypi"
   npm_repository   = var.echo_npm_repository_name != "" ? var.echo_npm_repository_name : "${var.repository_name}-npm"
   maven_repository = var.echo_maven_repository_name != "" ? var.echo_maven_repository_name : "${var.repository_name}-maven"
+  deb_repository   = var.echo_deb_repository_name != "" ? var.echo_deb_repository_name : "${var.repository_name}-deb"
 }
 
 # Docker proxy repository for Echo
@@ -230,6 +231,53 @@ resource "nexus_repository_maven_proxy" "echo_maven" {
   }
 
   routing_rule = var.routing_rule
+}
+
+# apt proxy repository for Echo's OS packages.
+#
+# `distribution` is left empty by default so the proxy serves every suite. Echo
+# images already have an apt source pinned to a specific suite (e.g. `trixie
+# main`) and only swap its URL prefix to point here, so the proxy has to pass
+# `dists/<suite>/...` straight through rather than bind to one distribution.
+resource "nexus_repository_apt_proxy" "echo_deb" {
+  count = var.create && var.echo_os_packages ? 1 : 0
+
+  name         = local.deb_repository
+  online       = var.repository_online
+  distribution = var.echo_os_distribution
+  flat         = var.echo_os_flat
+
+  storage {
+    blob_store_name                = var.blob_store_name
+    strict_content_type_validation = var.strict_content_type_validation
+  }
+
+  proxy {
+    remote_url       = var.echo_os_packages_url
+    content_max_age  = var.proxy_content_max_age
+    metadata_max_age = var.proxy_metadata_max_age
+  }
+
+  negative_cache {
+    enabled = var.negative_cache_enabled
+    ttl     = var.negative_cache_ttl
+  }
+
+  http_client {
+    blocked    = var.http_client_blocked
+    auto_block = var.http_client_auto_block
+  }
+
+  routing_rule = var.routing_rule
+
+  # A precondition rather than a variable validation: the rule depends on a
+  # second variable, which validation blocks only support from Terraform 1.9.
+  lifecycle {
+    precondition {
+      condition     = var.echo_os_packages_url != ""
+      error_message = "echo_os_packages_url must be set when echo_os_packages is enabled. Copy the repository URL from the Integrations page in the Echo platform."
+    }
+  }
 }
 
 # Optional: Create a content selector for the repository

--- a/echo-terraform-nexus-mirror/outputs.tf
+++ b/echo-terraform-nexus-mirror/outputs.tf
@@ -5,6 +5,7 @@ output "usage_instructions" {
     var.echo_library_pypi ? "PyPI:    pip install --index-url https://<nexus-host>/repository/${local.pypi_repository}/simple <package>" : "",
     var.echo_library_npm ? "npm:     npm install --registry https://<nexus-host>/repository/${local.npm_repository}/ <package>" : "",
     var.echo_library_maven ? "Maven:   add https://<nexus-host>/repository/${local.maven_repository} as a repository in your settings.xml" : "",
+    var.echo_os_packages ? "OS pkgs: in a Dockerfile built FROM an Echo image, run: echo-apt-mirror https://<nexus-host>/repository/${local.deb_repository}" : "",
   ])) : null
 }
 
@@ -20,4 +21,9 @@ output "library_repository_keys" {
     var.echo_library_npm ? local.npm_repository : "",
     var.echo_library_maven ? local.maven_repository : "",
   ])
+}
+
+output "os_package_repository_key" {
+  description = "Name of the apt proxy repository, if created."
+  value       = var.echo_os_packages ? local.deb_repository : null
 }

--- a/echo-terraform-nexus-mirror/variables.tf
+++ b/echo-terraform-nexus-mirror/variables.tf
@@ -121,6 +121,39 @@ variable "echo_maven_repository_name" {
   default     = ""
 }
 
+# --- OS packages (Debian) ---
+variable "echo_os_packages" {
+  type        = bool
+  description = "Provision the apt proxy that mirrors Echo's Debian repository"
+  default     = false
+}
+
+# Deliberately has no default: the upstream URL is supplied by the caller. The
+# Echo platform prefills it in the module invocation it generates.
+variable "echo_os_packages_url" {
+  type        = string
+  description = "URL of the Echo Debian repository. Required when echo_os_packages is enabled; copy it from the Integrations page in the Echo platform."
+  default     = ""
+}
+
+variable "echo_deb_repository_name" {
+  type        = string
+  description = "Override for the apt proxy repository name. Defaults to <repository_name>-deb."
+  default     = ""
+}
+
+variable "echo_os_distribution" {
+  type        = string
+  description = "Distribution to fetch. Empty proxies every distribution in the Echo repository, which is what Echo images expect."
+  default     = ""
+}
+
+variable "echo_os_flat" {
+  type        = bool
+  description = "Whether the upstream uses a flat layout. Echo uses a standard dists/pool layout, so this stays false."
+  default     = false
+}
+
 # Maven proxy policies (datadrivers/nexus requires an explicit maven block)
 variable "maven_version_policy" {
   type        = string

--- a/echo-terraform-nexus-mirror/versions.tf
+++ b/echo-terraform-nexus-mirror/versions.tf
@@ -1,5 +1,6 @@
 terraform {
-  required_version = ">= 1.0"
+  # 1.2 for resource lifecycle preconditions (see the apt proxy in main.tf).
+  required_version = ">= 1.2"
 
   required_providers {
     nexus = {


### PR DESCRIPTION
## Summary

- Adds an optional Debian/apt repository to all three mirror modules, each behind its own flag so existing image/library configs are untouched: `artifactory_remote_debian_repository` (JFrog Terraform), `RemoteDebianRepository` (JFrog Pulumi) and `nexus_repository_apt_proxy` (Nexus Terraform).
- Each module gains an `os_package_repository_key` output and an `echo-apt-mirror` line in `usage_instructions`.
- `echo_os_packages_url` deliberately has no default, since the Echo platform is what supplies it. Enforcing that depends on a second variable, which variable validation only supports from Terraform 1.9, so it uses a `lifecycle` precondition instead and `required_version` moves from `>= 1.0` to `>= 1.2`.
- The Nexus `distribution` field defaults to empty so the proxy serves every suite. Echo images pin their own suite and swap only the URL prefix, so the proxy has to pass `dists/<suite>/...` straight through rather than bind to one distribution.
- READMEs document the inputs and the `ARG APT_MIRROR` + `echo-apt-mirror` Dockerfile pattern for consuming the mirror.

## Test plan

- [ ] `terraform init && terraform validate` in both Terraform modules; `tsc --noEmit` for the Pulumi component
- [ ] Apply with `echo_os_packages = true` against a real Artifactory and Nexus, confirm the repository is created and its connection test passes
- [ ] Apply with `echo_os_packages = true` and no URL, confirm the precondition fails with the intended message
- [ ] From an Echo base image, point at the created mirror and confirm `apt-get update` plus an install succeed
- [ ] Confirm an existing image-only and library-only config still plans clean with no OS package resources

Companion PRs: the in-app setup steps live in `buildecho/platform`, the customer-facing guide in `buildecho/documentation`.

Made with [Cursor](https://cursor.com)